### PR TITLE
Window matcher for modmap and keymap

### DIFF
--- a/src/client/gnome_client.rs
+++ b/src/client/gnome_client.rs
@@ -59,6 +59,28 @@ impl Client for GnomeClient {
         }
         None
     }
+
+    fn current_window(&mut self) -> Option<String> {
+        self.connect();
+        let connection = match &mut self.connection {
+            Some(connection) => connection,
+            None => return None,
+        };
+        if let Ok(message) = connection.call_method(
+            Some("org.gnome.Shell"),
+            "/com/k0kubun/Xremap",
+            Some("com.k0kubun.Xremap"),
+            "ActiveWindow",
+            &(),
+        ) {
+            if let Ok(json) = message.body::<String>() {
+                if let Ok(window) = serde_json::from_str::<ActiveWindow>(&json) {
+                    return Some(window.title);
+                }
+            }
+        }
+        None
+    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,7 @@
 trait Client {
     fn supported(&mut self) -> bool;
     fn current_application(&mut self) -> Option<String>;
+    fn current_window(&mut self) -> Option<String>;
 }
 
 pub struct WMClient {
@@ -8,6 +9,7 @@ pub struct WMClient {
     client: Box<dyn Client>,
     supported: Option<bool>,
     last_application: String,
+    last_window: String,
 }
 
 impl WMClient {
@@ -17,6 +19,7 @@ impl WMClient {
             client,
             supported: None,
             last_application: String::new(),
+            last_window: String::new(),
         }
     }
 
@@ -35,6 +38,26 @@ impl WMClient {
             if &self.last_application != application {
                 self.last_application = application.clone();
                 println!("application: {}", application);
+            }
+        }
+        result
+    }
+
+    pub fn current_window(&mut self) -> Option<String> {
+        if self.supported.is_none() {
+            let supported = self.client.supported();
+            self.supported = Some(supported);
+            println!("application-client: {} (supported: {})", self.name, supported);
+        }
+        if !self.supported.unwrap() {
+            return None;
+        }
+
+        let result = self.client.current_window();
+        if let Some(window) = &result {
+            if &self.last_window != window {
+                self.last_window = window.clone();
+                println!("window: {}", window);
             }
         }
         result

--- a/src/client/null_client.rs
+++ b/src/client/null_client.rs
@@ -10,4 +10,8 @@ impl Client for NullClient {
     fn current_application(&mut self) -> Option<String> {
         None
     }
+
+    fn current_window(&mut self) -> Option<String> {
+        None
+    }
 }

--- a/src/client/sway_client.rs
+++ b/src/client/sway_client.rs
@@ -59,6 +59,10 @@ impl Client for SwayClient {
         }
         None
     }
+
+    fn current_window(&mut self) -> Option<String> {
+        None
+    }
 }
 
 // e.g. "/run/user/1000/sway-ipc.1000.2575.sock"

--- a/src/client/x11_client.rs
+++ b/src/client/x11_client.rs
@@ -107,4 +107,8 @@ impl Client for X11Client {
         }
         Some(wm_class)
     }
+
+    fn current_window(&mut self) -> Option<String> {
+        None
+    }
 }

--- a/src/config/application.rs
+++ b/src/config/application.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Deserializer};
 // TODO: Use trait to allow only either `only` or `not`
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Application {
+pub struct OnlyOrNot {
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub only: Option<Vec<String>>,
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -1,5 +1,5 @@
 use crate::config::action::{Action, Actions};
-use crate::config::application::Application;
+use crate::config::application::OnlyOrNot;
 use crate::config::key_press::{KeyPress, Modifier, ModifierState};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
@@ -11,7 +11,8 @@ pub struct Keymap {
     pub name: String,
     #[serde(deserialize_with = "deserialize_remap")]
     pub remap: HashMap<KeyPress, Vec<Action>>,
-    pub application: Option<Application>,
+    pub application: Option<OnlyOrNot>,
+    pub window: Option<OnlyOrNot>,
 }
 
 fn deserialize_remap<'de, D>(deserializer: D) -> Result<HashMap<KeyPress, Vec<Action>>, D::Error>

--- a/src/config/modmap.rs
+++ b/src/config/modmap.rs
@@ -1,4 +1,4 @@
-use crate::config::application::Application;
+use crate::config::application::OnlyOrNot;
 use crate::config::key::deserialize_key;
 use crate::config::key_action::KeyAction;
 use evdev::Key;
@@ -12,7 +12,8 @@ pub struct Modmap {
     pub name: String,
     #[serde(deserialize_with = "deserialize_remap")]
     pub remap: HashMap<Key, KeyAction>,
-    pub application: Option<Application>,
+    pub application: Option<OnlyOrNot>,
+    pub window: Option<OnlyOrNot>,
 }
 
 fn deserialize_remap<'de, D>(deserializer: D) -> Result<HashMap<Key, KeyAction>, D::Error>

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -139,6 +139,24 @@ fn test_keymap_mark() {
     "})
 }
 
+#[test]
+fn test_window() {
+    assert_parse(indoc! {"
+    modmap:
+      - remap:
+          Alt_L: Ctrl_L
+        window:
+          not:
+            - Gnome-terminal
+    keymap:
+      - remap:
+          Alt-S: Ctrl-S
+        application:
+          only:
+            - Gnome-terminal
+    "})
+}
+
 fn assert_parse(yaml: &str) {
     let result: Result<Config, Error> = serde_yaml::from_str(yaml);
     if let Err(e) = result {


### PR DESCRIPTION
## Example
```yml
modmap:
  - remap:
      CapsLock: Esc
    window:
      only: Terminal
keymap:
  - remap:
      RO: Shift-RO
    window:
      not: Terminal
```