### PR TITLE
wlroots client support window title match

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ modmap:
       not: [Application, ...]
       # or
       only: [Application, ...]
+    window: # Optional (only wlroots clients supported)
+      not: [/regex of window title/, ...]
+      # or
+      only: [/regex of window title/, ...]
     device: # Optional
       not: [Device, ...]
       # or
@@ -262,6 +266,10 @@ keymap:
       not: [Application, ...]
       # or
       only: [Application, ...]
+    window: # Optional (only wlroots clients supported)
+      not: [/regex of window title/, ...]
+      # or
+      only: [/regex of window title/, ...]
     device: # Optional
       not: [Device, ...]
       # or

--- a/src/client/gnome_client.rs
+++ b/src/client/gnome_client.rs
@@ -24,6 +24,10 @@ impl Client for GnomeClient {
         self.connect();
         self.current_application().is_some()
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         self.connect();

--- a/src/client/hypr_client.rs
+++ b/src/client/hypr_client.rs
@@ -12,6 +12,10 @@ impl Client for HyprlandClient {
     fn supported(&mut self) -> bool {
         true
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         if let Ok(win_opt) = HyprClient::get_active() {

--- a/src/client/kde_client.rs
+++ b/src/client/kde_client.rs
@@ -173,6 +173,10 @@ impl Client for KdeClient {
         }
         conn_res.is_ok()
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         let aw = self.active_window.lock().unwrap();

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,6 +1,7 @@
 pub trait Client {
     fn supported(&mut self) -> bool;
     fn current_application(&mut self) -> Option<String>;
+    fn current_window(&mut self) -> Option<String>;
 }
 
 pub struct WMClient {
@@ -8,6 +9,7 @@ pub struct WMClient {
     client: Box<dyn Client>,
     supported: Option<bool>,
     last_application: String,
+    last_window: String,
 }
 
 impl WMClient {
@@ -17,7 +19,27 @@ impl WMClient {
             client,
             supported: None,
             last_application: String::new(),
+            last_window: String::new(),
         }
+    }
+    pub fn current_window(&mut self) -> Option<String> {
+        if self.supported.is_none() {
+            let supported = self.client.supported();
+            self.supported = Some(supported);
+            println!("application-client: {} (supported: {})", self.name, supported);
+        }
+        if !self.supported.unwrap() {
+            return None;
+        }
+
+        let result = self.client.current_window();
+        if let Some(window) = &result {
+            if &self.last_window != window {
+                self.last_window = window.clone();
+                println!("window: {}", window);
+            }
+        }
+        result
     }
 
     pub fn current_application(&mut self) -> Option<String> {

--- a/src/client/null_client.rs
+++ b/src/client/null_client.rs
@@ -6,6 +6,9 @@ impl Client for NullClient {
     fn supported(&mut self) -> bool {
         false
     }
+    fn current_window(&mut self) -> Option<String> {
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         None

--- a/src/client/sway_client.rs
+++ b/src/client/sway_client.rs
@@ -40,6 +40,10 @@ impl Client for SwayClient {
         self.connect();
         self.connection.is_some()
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         self.connect();

--- a/src/client/x11_client.rs
+++ b/src/client/x11_client.rs
@@ -48,6 +48,10 @@ impl Client for X11Client {
         return self.connection.is_some();
         // TODO: Test XGetInputFocus and focused_window > 0?
     }
+    fn current_window(&mut self) -> Option<String> {
+        // TODO:  not implemented
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         self.connect();

--- a/src/config/application.rs
+++ b/src/config/application.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer};
 // TODO: Use trait to allow only either `only` or `not`
 #[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct Application {
+pub struct OnlyOrNot {
     #[serde(default, deserialize_with = "deserialize_matchers")]
     pub only: Option<Vec<ApplicationMatcher>>,
     #[serde(default, deserialize_with = "deserialize_matchers")]

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -1,5 +1,5 @@
 use crate::config::application::deserialize_string_or_vec;
-use crate::config::application::Application;
+use crate::config::application::OnlyOrNot;
 use crate::config::key_press::KeyPress;
 use crate::config::keymap_action::{Actions, KeymapAction};
 use evdev::Key;
@@ -17,7 +17,8 @@ pub struct Keymap {
     pub name: String,
     #[serde(deserialize_with = "deserialize_remap")]
     pub remap: HashMap<KeyPress, Vec<KeymapAction>>,
-    pub application: Option<Application>,
+    pub application: Option<OnlyOrNot>,
+    pub window: Option<OnlyOrNot>,
     pub device: Option<Device>,
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub mode: Option<Vec<String>>,
@@ -41,7 +42,8 @@ where
 pub struct KeymapEntry {
     pub actions: Vec<KeymapAction>,
     pub modifiers: Vec<Modifier>,
-    pub application: Option<Application>,
+    pub application: Option<OnlyOrNot>,
+    pub title: Option<OnlyOrNot>,
     pub device: Option<Device>,
     pub mode: Option<Vec<String>>,
     pub exact_match: bool,
@@ -65,6 +67,7 @@ pub fn build_keymap_table(keymaps: &Vec<Keymap>) -> HashMap<Key, Vec<KeymapEntry
                 actions: actions.to_vec(),
                 modifiers: key_press.modifiers.clone(),
                 application: keymap.application.clone(),
+                title: keymap.window.clone(),
                 device: keymap.device.clone(),
                 mode: keymap.mode.clone(),
                 exact_match: keymap.exact_match,

--- a/src/config/modmap.rs
+++ b/src/config/modmap.rs
@@ -1,4 +1,4 @@
-use crate::config::application::Application;
+use crate::config::application::OnlyOrNot;
 use crate::config::key::deserialize_key;
 use crate::config::modmap_action::ModmapAction;
 use evdev::Key;
@@ -14,7 +14,8 @@ pub struct Modmap {
     pub name: String,
     #[serde(deserialize_with = "deserialize_remap")]
     pub remap: HashMap<Key, ModmapAction>,
-    pub application: Option<Application>,
+    pub application: Option<OnlyOrNot>,
+    pub window: Option<OnlyOrNot>,
     pub device: Option<Device>,
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -23,6 +23,9 @@ impl Client for StaticClient {
     fn supported(&mut self) -> bool {
         true
     }
+    fn current_window(&mut self) -> Option<String> {
+        None
+    }
 
     fn current_application(&mut self) -> Option<String> {
         self.current_application.clone()


### PR DESCRIPTION
demo:
```
  - name: kitty emacs
    application:
      only: [kitty]
    window:
      only: /GNU\/Emacs/
    remap:
      super-C-w: [C-x ,k] 
      
  - name: kitty
    application:
      only: [kitty]
    remap:
      super-C-w: super-C-q
```
When the terminal window title match `GNU/Emacs` (when I run `emacs -nw` in kitty)  ,`super-C-w` would send `C-x k` 
else it would send `super-C-q`

currently only `wlroots client` is supported 
https://github.com/xremap/xremap/issues/150 related