### PR TITLE
WIP: KDE: Add support for window matching.

### DIFF
--- a/src/client/kde_client.rs
+++ b/src/client/kde_client.rs
@@ -174,12 +174,12 @@ impl Client for KdeClient {
         conn_res.is_ok()
     }
     fn current_window(&mut self) -> Option<String> {
-        // TODO:  not implemented
-        None
+        let aw = self.active_window.lock().ok()?;
+        Some(aw.title.clone())
     }
 
     fn current_application(&mut self) -> Option<String> {
-        let aw = self.active_window.lock().unwrap();
+        let aw = self.active_window.lock().ok()?;
         Some(aw.res_class.clone())
     }
 }


### PR DESCRIPTION
Wlroots clients got window-matching, but the kde-client had already information about the caption of the currently activated window so this PR hooks it up.