### PR TITLE
better to send no key for skip event

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -354,7 +354,7 @@ impl EventHandler {
 
                 if skip_key_event {
                     // Do not dispatch the original key
-                    vec![(Key::KEY_UNKNOWN, value)]
+                    vec![]
                 } else {
                     // dispatch the original key
                     vec![(key, value)]


### PR DESCRIPTION
I didn't think much about it on my first patch but when skip_key_event
is set the KEY_UNKNOWN is repeated. Better to send no key at all.
