### PR TITLE
Allow keymap actions with no action

### DIFF
--- a/src/config/keymap_action.rs
+++ b/src/config/keymap_action.rs
@@ -135,3 +135,50 @@ impl Actions {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::KeymapAction;
+    use crate::config::key_press::KeyPress;
+    use crate::config::key_press::Modifier;
+    use evdev::Key;
+
+    #[test]
+    fn test_keypress_action() {
+        test_yaml_parsing_key_press(
+            "c-x",
+            KeyPress {
+                key: Key::KEY_X,
+                modifiers: vec![Modifier::Control],
+            },
+        );
+    }
+
+    #[test]
+    fn test_launch_action() {
+        test_yaml_parsing_key_launch("{launch: []}", vec![]);
+        test_yaml_parsing_key_launch("{launch: [\"bla\"]}", vec!["bla".into()]);
+    }
+
+    //
+    // util
+    //
+
+    fn test_yaml_parsing_key_press(yaml: &str, expected: KeyPress) {
+        match serde_yaml::from_str(yaml).unwrap() {
+            KeymapAction::KeyPress(keyp) => {
+                assert_eq!(keyp, expected);
+            }
+            _ => panic!("unexpected type"),
+        }
+    }
+
+    fn test_yaml_parsing_key_launch(yaml: &str, expected: Vec<String>) {
+        match serde_yaml::from_str(yaml).unwrap() {
+            KeymapAction::Launch(vect) => {
+                assert_eq!(vect, expected);
+            }
+            _ => panic!("unexpected type"),
+        }
+    }
+}

--- a/src/config/keymap_action.rs
+++ b/src/config/keymap_action.rs
@@ -123,6 +123,8 @@ where
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum Actions {
+    // Allows keychords to map to null, which means no actions.
+    NoAction,
     Action(KeymapAction),
     Actions(Vec<KeymapAction>),
 }
@@ -130,6 +132,7 @@ pub enum Actions {
 impl Actions {
     pub fn into_vec(self) -> Vec<KeymapAction> {
         match self {
+            Actions::NoAction => vec![],
             Actions::Action(action) => vec![action],
             Actions::Actions(actions) => actions,
         }
@@ -141,6 +144,7 @@ mod tests {
     use super::KeymapAction;
     use crate::config::key_press::KeyPress;
     use crate::config::key_press::Modifier;
+    use crate::config::keymap_action::Actions;
     use evdev::Key;
 
     #[test]
@@ -158,6 +162,14 @@ mod tests {
     fn test_launch_action() {
         test_yaml_parsing_key_launch("{launch: []}", vec![]);
         test_yaml_parsing_key_launch("{launch: [\"bla\"]}", vec!["bla".into()]);
+    }
+
+    #[test]
+    fn test_null_action() {
+        if let Actions::NoAction = serde_yaml::from_str("null").unwrap() {
+            return;
+        }
+        panic!("unexpected type");
     }
 
     //

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -257,6 +257,12 @@ fn test_yaml_no_keymap_action() {
     keymap:
       - remap:
           f12: []
+    "});
+
+    yaml_assert_parse(indoc! {"
+    keymap:
+      - remap:
+          f12: null
     "})
 }
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -252,6 +252,15 @@ fn test_yaml_fail_on_data_outside_of_config_model() {
 }
 
 #[test]
+fn test_yaml_no_keymap_action() {
+    yaml_assert_parse(indoc! {"
+    keymap:
+      - remap:
+          f12: []
+    "})
+}
+
+#[test]
 fn test_toml_modmap_basic() {
     toml_assert_parse(indoc! {"
     [[modmap]]
@@ -520,6 +529,15 @@ fn test_toml_fail_on_data_outside_of_config_model() {
 
     [modmap.application]
     only = \"Google-chrome\"
+    "})
+}
+
+#[test]
+fn test_toml_no_keymap_action() {
+    toml_assert_parse(indoc! {"
+    [[keymap]]
+    [keymap.remap]
+    f12 = []
     "})
 }
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -697,6 +697,10 @@ impl EventHandler {
 }
 
 fn is_remap(actions: &Vec<KeymapAction>) -> bool {
+    if actions.len() == 0 {
+        return false;
+    }
+
     actions.iter().all(|x| match x {
         KeymapAction::Remap(..) => true,
         _ => false,

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -698,6 +698,12 @@ impl EventHandler {
 
 fn is_remap(actions: &Vec<KeymapAction>) -> bool {
     if actions.len() == 0 {
+        // When actions is empty it could either be regarded as an empty remap
+        //  or no actions. In principle that shouldn't matter, but remap is
+        //  implemented to gather all defined remaps, not just the first match.
+        // Here we regard an empty actions as non-remap, so the matching will stop
+        //  here, and no actions are performed. The possibly following remaps are
+        //  hence ignored.
         return false;
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -684,7 +684,7 @@ fn test_mixing_keypress_and_remap_in_keymap_action() {
 
 #[test]
 fn test_mixing_no_keypress_and_remap_in_keymap_action() {
-    // The first match doesn't stop the search for matches. So the last remap will be used.
+    // The first match stops the search for matches. So the last remap isn't used.
     assert_actions(
         indoc! {"
         keymap:
@@ -703,10 +703,7 @@ fn test_mixing_no_keypress_and_remap_in_keymap_action() {
         ],
         vec![
             Action::KeyEvent(KeyEvent::new(Key::KEY_F12, KeyValue::Release)),
-            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
-            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
-            Action::Delay(Duration::from_nanos(0)),
-            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
         ],
     )
@@ -725,10 +722,23 @@ fn test_no_keymap_action() {
             Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_F12, KeyValue::Release)),
         ],
         vec![
-            //It's unexpected that something is emitted here. The empty list of keys, should mean nothing.
-            Action::KeyEvent(KeyEvent::new(Key::KEY_F12, KeyValue::Press)),
+            //This is just release, so the key is not emitted.
             Action::KeyEvent(KeyEvent::new(Key::KEY_F12, KeyValue::Release)),
         ],
+    );
+
+    //Same test with the null keyword
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              f12: null
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_F12, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_F12, KeyValue::Release)),
+        ],
+        vec![Action::KeyEvent(KeyEvent::new(Key::KEY_F12, KeyValue::Release))],
     )
 }
 


### PR DESCRIPTION
Fix #297

### Feature
Suppress the default action with either of these to remaps:

```yml
keymap:
    - remap:
        f11: []
        f12: null
```
`null` is syntactic sugar for an empty vector.

### Commits
- Add tests of existing functionality.
  - I have added tests to illustrate the changes this commit will cause.
- Allow keymap actions to have no action
  - The function is_remap is changed to not consider an empty keymap action as a nested remap.
  - `Actions` struct for parsing config files has a new enum `NoAction` that turns into an empty vec. This allows:
    1. `null` for keymap action
    2. `null` for actions in nested remaps.
    3. `null`  for press/release key actions.

### Breaking changes
I'm not sure these are breaking changes, as they are quite strange use cases, but I will call them out, so they can be considered.

#### Change 1

[test_mixing_keypress_and_remap_in_keymap_action](https://github.com/wistoft/xremap/commit/c6d874c1edc60d32630eb4ca23c52accd705ef60#diff-a0262fea108af44a98cc49e5eb72641963dd816513f2d0a22eb738fcfed55ebeL686) shows that the following config will change behavior:
```yml
keymap:
    - remap:
        f12: []
    - remap:
        f12:
        - remap:
            a: b
```
`f12` would previously activate the nested remap, because the `f12: []` was effectively ignored. Now `f12: []` means emit nothing, so the search stops there.

I think this is acceptable, because `f12: []` had no effect before. Why would user's have it in their config files.

#### Change 2

[test_no_keymap_action](https://github.com/wistoft/xremap/commit/c6d874c1edc60d32630eb4ca23c52accd705ef60#diff-a0262fea108af44a98cc49e5eb72641963dd816513f2d0a22eb738fcfed55ebeL728) shows that the following config will change behavior:

```yml
keymap:
    - remap:
        f12: []
```
`f12` would previously emitted `f12`, as if there was no configuration. Now it will suppress `f12`.

I think this is acceptable because the config was a no-op before, so user's could just remove it. And why would they have it in the first place.