### PR TITLE
Fix cargo warnings

### DIFF
--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -13,6 +13,7 @@ use super::key_press::Modifier;
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Keymap {
+    #[allow(dead_code)]
     #[serde(default = "String::new")]
     pub name: String,
     #[serde(deserialize_with = "deserialize_remap")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -43,6 +43,7 @@ pub struct Config {
 
     // Data is not used by any part of the application.
     // but can be used with Anchors and Aliases
+    #[allow(dead_code)]
     #[serde(default)]
     pub shared: IgnoredAny,
 

--- a/src/config/modmap.rs
+++ b/src/config/modmap.rs
@@ -10,6 +10,7 @@ use super::device::Device;
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Modmap {
+    #[allow(dead_code)]
     #[serde(default = "String::new")]
     pub name: String,
     #[serde(deserialize_with = "deserialize_remap")]

--- a/src/config/modmap_action.rs
+++ b/src/config/modmap_action.rs
@@ -32,7 +32,7 @@ pub struct MultiPurposeKey {
 #[derive(Clone, Debug, Deserialize)]
 pub struct PressReleaseKey {
     #[serde(default)]
-    pub skip_key_event: bool ,
+    pub skip_key_event: bool,
     #[serde(deserialize_with = "deserialize_actions")]
     pub press: Vec<KeymapAction>,
     #[serde(deserialize_with = "deserialize_actions")]


### PR DESCRIPTION
Just a little clean up, that removes warnings when running: `cargo check`