### PR TITLE
[wip] Support keyboard layout in config file

### DIFF
--- a/src/config/key.rs
+++ b/src/config/key.rs
@@ -1,3 +1,4 @@
+use super::keyboard_layout::apply_keyboard_layout;
 use crate::event_handler::DISGUISED_EVENT_OFFSETTER;
 use evdev::Key;
 use serde::{Deserialize, Deserializer};
@@ -15,6 +16,11 @@ where
 pub fn parse_key(input: &str) -> Result<Key, Box<dyn Error>> {
     // Everything is case-insensitive
     let name = input.to_uppercase();
+
+    // Use pseudo key from user-defined keyboard layout
+    if let Some(key) = apply_keyboard_layout(&name) {
+        return Ok(key);
+    }
 
     // Original evdev scancodes should always work
     if let Ok(key) = Key::from_str(&name) {

--- a/src/config/keyboard_layout.rs
+++ b/src/config/keyboard_layout.rs
@@ -1,0 +1,54 @@
+use evdev::Key;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+
+lazy_static! {
+  /// Map the evdev keys to labels on the keyboard.
+  ///  - It's the same mapping the OS does to change keyboard layouts. Xremap also
+  ///      needs to do it, so config files can use the keyboard layout.
+  ///  - It's possible to use pseudo keys (only xremap knows of), because they're reversed before emitting.
+  ///  - The evdev keys are defined here: https://github.com/emberian/evdev/blob/master/src/scancodes.rs
+  ///     - They can also be obtained by running `RUST_LOG=debug xremap config.yml`
+  ///     - They are close to the QWERTY keyboard layout: https://en.wikipedia.org/wiki/QWERTY
+  ///  - Keys, that map to the same key on your keyboard, can be omitted.
+  pub static ref keyboard_layout_definition: HashMap<u16, &'static str> = HashMap::from([
+      //for AZERTY - only partial layout
+      // (Key::KEY_Q.code(), "A"),
+      // (Key::KEY_A.code(), "Q"),
+      // (Key::KEY_W.code(), "Z"),
+      // (Key::KEY_Z.code(), "W"),
+
+      //for QWERTY danish layout
+      (Key::KEY_MINUS.code(), "+"),
+      (Key::KEY_EQUAL.code(), "´"),
+      (Key::KEY_LEFTBRACE.code(), "Å"),
+      (Key::KEY_RIGHTBRACE.code(), "¨"),
+      (Key::KEY_SEMICOLON.code(), "Æ"),
+      (Key::KEY_APOSTROPHE.code(), "Ø"),
+      (Key::KEY_BACKSLASH.code(), "'"),
+      (Key::KEY_SLASH.code(), "dash"), // Can't use the pseudokey: `-`, because it would be a syntax error in config file.
+      (Key::KEY_102ND.code(), "<"),
+  ]);
+
+  // Map from evdev key to pseudo_key_code
+  pub static ref keyboard_layout: HashMap<u16, u16> = keyboard_layout_definition.clone().into_iter().map(|(a, _)| (a, 40000 + a)).collect();
+
+  // Map from pseudo_key_code to evdev key
+  pub static ref reverse_keyboard_layout: HashMap<u16, u16> = keyboard_layout.iter().map(|(&a, &b)| (b, a)).collect();
+
+  // Map from user-defined key to pseudo_key_code
+  pub static ref keyboard_layout_keys: HashMap<String, u16> = keyboard_layout_definition.clone().into_iter().map(|(a, b)| (b.to_ascii_uppercase(), 40000 + a)).collect();
+
+}
+
+///
+/// - The key_name is what ever the user wants. It doesn't have to be related to the evdev key names.
+///
+pub fn apply_keyboard_layout(key_name: &str) -> Option<Key> {
+    let key_name = key_name.to_uppercase();
+
+    keyboard_layout_keys
+        .get(&format!("{}", key_name))
+        .or_else(|| keyboard_layout_keys.get(&format!("KEY_{}", key_name)))
+        .map(|&code| Key(code))
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@ pub mod application;
 pub mod device;
 mod key;
 pub mod key_press;
+pub mod keyboard_layout;
 pub mod keymap;
 pub mod keymap_action;
 mod modmap;

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -9,6 +9,7 @@ use crate::config::remap::Remap;
 use crate::device::InputDeviceInfo;
 use crate::event::{Event, KeyEvent, RelativeEvent};
 use crate::{config, Config};
+use config::keyboard_layout::keyboard_layout;
 use evdev::Key;
 use lazy_static::lazy_static;
 use log::debug;
@@ -116,6 +117,15 @@ impl EventHandler {
     ) -> Result<bool, Box<dyn Error>> {
         self.application_cache = None; // expire cache
         self.title_cache = None; // expire cache
+
+        // apply keyboard layout
+
+        let event = if let Some(&new_key_code) = keyboard_layout.get(&event.code()) {
+            &KeyEvent::new_with(new_key_code, event.value())
+        } else {
+            event
+        };
+
         let key = Key::new(event.code());
         debug!("=> {}: {:?}", event.value(), &key);
 


### PR DESCRIPTION
This PR is not finished, but is a proof of concept. For [issue](https://github.com/xremap/xremap/issues/552)

### Description

User will be able to define their keyboard layout in the config file, and then xremap respects that for all definitions in the config file.

### Sample config file

```yml
keyboard_layout:
  # Partial AZERTY layout
  q: a
  a: q

keymap:
  remap:
    control-a: k
```
Pressing the `control-a` on an AZERTY keyboard will trigger the defined remap. Even though evdev emits a `KEY_Q` to xremap.
 
### Implementation

Keyboard layout is applied before events are processed by xremap, and inversely applied when emitting keys. This means that xremap internally have some pseudo-keys, which the user can give a descriptive name.

The PR can be implemented as non-breaking, by letting users define a keyboard layout in the config file. If they don't have such configuration, the functionality would have no effect at all.

### Testing the PR

Change the hardcoded keyboard layout in [src/config/keyboard_layout.rs](https://github.com/xremap/xremap/pull/553/files#diff-91b4c370c7b1c37dfa4c3f85550665b2813939f05ef869c01d09fd63053aec0fR21). Then compile xremap as normal.