### PR TITLE
Fix issue #492: timeout_key accept a key sequence

### DIFF
--- a/src/config/keymap_action.rs
+++ b/src/config/keymap_action.rs
@@ -93,9 +93,10 @@ where
     Ok(Remap {
         remap: action.remap.into_iter().map(|(k, v)| (k, v.into_vec())).collect(),
         timeout: action.timeout_millis.map(Duration::from_millis),
-        timeout_key: if let Some(key) = action.timeout_key {
-            match parse_key(&key) {
-                Ok(key) => Some(key),
+        timeout_key: if let Some(keys) = action.timeout_key {
+            let parsed_keys: Result<Vec<_>, _> = keys.into_iter().map(|key| parse_key(&key)).collect();
+            match parsed_keys {
+                Ok(parsed_keys) => Some(parsed_keys),
                 Err(e) => return Err(de::Error::custom(e.to_string())),
             }
         } else {

--- a/src/config/remap.rs
+++ b/src/config/remap.rs
@@ -1,6 +1,7 @@
 use evdev::KeyCode as Key;
 use serde::Deserialize;
 
+use crate::config::application::deserialize_string_or_vec;
 use crate::config::key_press::KeyPress;
 use crate::config::keymap_action::KeymapAction;
 use std::collections::HashMap;
@@ -20,5 +21,6 @@ pub struct Remap {
 pub struct RemapActions {
     pub remap: HashMap<KeyPress, Actions>,
     pub timeout_millis: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub timeout_key: Option<Vec<String>>,
 }

--- a/src/config/remap.rs
+++ b/src/config/remap.rs
@@ -12,7 +12,7 @@ use super::keymap_action::Actions;
 pub struct Remap {
     pub remap: HashMap<KeyPress, Vec<KeymapAction>>,
     pub timeout: Option<Duration>,
-    pub timeout_key: Option<Key>,
+    pub timeout_key: Option<Vec<Key>>,
 }
 
 // USed only for deserialization
@@ -20,5 +20,5 @@ pub struct Remap {
 pub struct RemapActions {
     pub remap: HashMap<KeyPress, Actions>,
     pub timeout_millis: Option<u64>,
-    pub timeout_key: Option<String>,
+    pub timeout_key: Option<Vec<String>>,
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -163,7 +163,23 @@ fn test_yaml_keymap_remap() {
               C-s:
                 remap:
                   x: C-z
-            timeout_key: [Down]
+            timeout_key: Down
+            timeout_millis: 1000
+    "})
+}
+
+#[test]
+fn test_yaml_keymap_remap_timeout_as_sequence() {
+    yaml_assert_parse(indoc! {"
+    keymap:
+      - remap:
+          C-x:
+            remap:
+              s: C-w
+              C-s:
+                remap:
+                  x: C-z
+            timeout_key: [Down,Up]
             timeout_millis: 1000
     "})
 }
@@ -430,7 +446,22 @@ fn test_toml_keymap_remap() {
     toml_assert_parse(indoc! {"
     [[keymap]]
     [keymap.remap.C-x]
-    timeout_key = [ \"Down\" ]
+    timeout_key = \"Down\"
+    timeout_millis = 1_000
+
+    [keymap.remap.C-x.remap]
+    s = \"C-w\"
+
+    [keymap.remap.C-x.remap.C-s.remap]
+    x = \"C-z\"
+    "})
+}
+#[test]
+fn test_toml_keymap_remap_timeout_key_sequence() {
+    toml_assert_parse(indoc! {"
+    [[keymap]]
+    [keymap.remap.C-x]
+    timeout_key = [ \"Down\", \"UP\" ]
     timeout_millis = 1_000
 
     [keymap.remap.C-x.remap]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -163,7 +163,7 @@ fn test_yaml_keymap_remap() {
               C-s:
                 remap:
                   x: C-z
-            timeout_key: Down
+            timeout_key: [Down]
             timeout_millis: 1000
     "})
 }
@@ -430,7 +430,7 @@ fn test_toml_keymap_remap() {
     toml_assert_parse(indoc! {"
     [[keymap]]
     [keymap.remap.C-x]
-    timeout_key = \"Down\"
+    timeout_key = [ \"Down\" ]
     timeout_millis = 1_000
 
     [keymap.remap.C-x.remap]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -549,9 +549,7 @@ impl EventHandler {
                         // TODO: Consider handling the timer in ActionDispatcher
                         self.override_timer.unset()?;
                         self.override_timer.set(expiration, TimerSetTimeFlags::empty())?;
-                        self.override_timeout_key =
-                            <std::option::Option<Vec<evdev::Key>> as Clone>::clone(&timeout_key)
-                                .or_else(|| Some(vec![*key]));
+                        self.override_timeout_key = timeout_key.clone().or_else(|| Some(vec![*key]))
                     }
                 }
             }


### PR DESCRIPTION
fix https://github.com/xremap/xremap/issues/492
# Feature
timeout_key  accept a key sequence :
```
keymap:
  - remap:
      J:
        remap:
          K: Esc
        timeout_key: [A, B, C]
        timeout_millis: 150
```