### PR TITLE
Add sleep KeymapAction

### DIFF
--- a/src/config/keymap_action.rs
+++ b/src/config/keymap_action.rs
@@ -29,6 +29,8 @@ pub enum KeymapAction {
     WithMark(KeyPress),
     #[serde(deserialize_with = "deserialize_escape_next_key")]
     EscapeNextKey(bool),
+    #[serde(deserialize_with = "deserialize_sleep")]
+    Sleep(u64),
 
     // Internals
     #[serde(skip)]
@@ -117,6 +119,19 @@ where
         }
     }
     Err(de::Error::custom("not a map with a single \"escape_next_key\" key"))
+}
+
+fn deserialize_sleep<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut action = HashMap::<String, u64>::deserialize(deserializer)?;
+    if let Some(set) = action.remove("sleep") {
+        if action.is_empty() {
+            return Ok(set);
+        }
+    }
+    Err(de::Error::custom("not a map with a single \"sleep\" key"))
 }
 
 // Used only for deserializing Vec<Action>

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -545,6 +545,7 @@ impl EventHandler {
             KeymapAction::SetMark(set) => self.mark_set = *set,
             KeymapAction::WithMark(key_press) => self.send_key_press(&self.with_mark(key_press)),
             KeymapAction::EscapeNextKey(escape_next_key) => self.escape_next_key = *escape_next_key,
+            KeymapAction::Sleep(millis) => self.send_action(Action::Delay(Duration::from_millis(*millis))),
             KeymapAction::SetExtraModifiers(keys) => {
                 self.extra_modifiers.clear();
                 for key in keys {


### PR DESCRIPTION
Fix #535

Adds a new enum: `KeymapAction::Sleep`, which can be used to sleep when emitting actions.

The sleep action can be used for press/release keys and in keymap:

```yml
modmap:
  - remap:
      # When releasing f12 it will sleep 500ms before emitting b.
      f12:
        press: a
        release: [{ sleep: 500 }, b]

keymap:
  - remap:
      # Will emit KEY_A rightaway, sleep 500ms and then emit KEY_B.
      f11: [a, { sleep: 500 }, b]
``` 

The sleep is synchronous and will block all processing, so key events will queue up. It will for instance not be possible to stop xremap by typing `control-c` in the terminal, until the sleep is done.

If the mouse is captured, then the mouse will be unresponsive while sleeping. It can't move as all its events is queue up.