### PR TITLE
Allow matching any key

### DIFF
--- a/src/config/key.rs
+++ b/src/config/key.rs
@@ -1,4 +1,4 @@
-use crate::event_handler::DISGUISED_EVENT_OFFSETTER;
+use crate::event_handler::{DISGUISED_EVENT_OFFSETTER, KEY_MATCH_ANY};
 use evdev::Key;
 use serde::{Deserialize, Deserializer};
 use std::error::Error;
@@ -119,6 +119,7 @@ pub fn parse_key(input: &str) -> Result<Key, Box<dyn Error>> {
             REL_WHEEL_HI_RES = 0x0b,
             REL_HWHEEL_HI_RES = 0x0c,
         */
+        "ANY" => KEY_MATCH_ANY,
         // End of custom scancodes
 
         // else

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -25,6 +25,10 @@ use std::time::{Duration, Instant};
 // to prevent conflating disguised relative events with other events.
 pub const DISGUISED_EVENT_OFFSETTER: u16 = 59974;
 
+// This const is defined a keycode for a configuration key used to match any key.
+// It's the offset of XHIRES_LEFTSCROLL + 1
+pub const KEY_MATCH_ANY: Key = Key(DISGUISED_EVENT_OFFSETTER + 26);
+
 pub struct EventHandler {
     // Currently pressed modifier keys
     modifiers: HashSet<Key>,
@@ -143,6 +147,9 @@ impl EventHandler {
                     self.escape_next_key = false
                 } else if let Some(actions) = self.find_keymap(config, &key, device)? {
                     self.dispatch_actions(&actions, &key)?;
+                    continue;
+                } else if let Some(actions) = self.find_keymap(config, &KEY_MATCH_ANY, device)? {
+                    self.dispatch_actions(&actions, &KEY_MATCH_ANY)?;
                     continue;
                 }
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -123,8 +123,8 @@ fn verify_disguised_relative_events() {
     // is a bigger number than the biggest one a scancode had at the time of writing this (26 december 2022)
     assert!(0x2e7 < DISGUISED_EVENT_OFFSETTER);
     // and that it's not big enough that one of the "disguised" events's scancode would overflow.
-    // (the largest of those events is equal to DISGUISED_EVENT_OFFSETTER + 25)
-    assert!(DISGUISED_EVENT_OFFSETTER <= u16::MAX - 25)
+    // (the largest of those events is equal to DISGUISED_EVENT_OFFSETTER + 26)
+    assert!(DISGUISED_EVENT_OFFSETTER <= u16::MAX - 26)
 }
 
 #[test]
@@ -740,6 +740,32 @@ fn test_no_keymap_action() {
         ],
         vec![Action::KeyEvent(KeyEvent::new(Key::KEY_F12, KeyValue::Release))],
     )
+}
+
+#[test]
+fn test_any_key() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              a: b
+              ANY: null
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_C, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_C, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_C, KeyValue::Release)),
+        ],
+    );
 }
 
 fn assert_actions(config_yaml: &str, events: Vec<Event>, actions: Vec<Action>) {


### PR DESCRIPTION
Current configuration is allowing to match a key and remap it. While it is useful for must cases, it is less useful when trying to disable shortcuts. If there are a lot of shortcuts to disable, it may be easier (and better for security) to disable all shortcuts except some.

This PR is adding a new "virtual" key used to match all keys. For instance, using:
```
keymap:
- remap:
    a: b
    ANY: null
```
will result in disabling all keyboards keys except ``KEY_A``, which is remapped to ``KEY_B``.

In case of shortcuts, this will disable all ``C-$KEY`` except ``C-p``:
```
keymap:
- exact_match: true
  remap:
    C-p: C-p
    C-ANY: reserved
```