### PR TITLE
Fix static_mut_refs warning

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -6,7 +6,6 @@ use derive_where::derive_where;
 use evdev::uinput::{VirtualDevice, VirtualDeviceBuilder};
 use evdev::{AttributeSet, BusType, Device, FetchEventsSynced, InputId, Key, RelativeAxisType};
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fs::read_dir;
@@ -38,9 +37,7 @@ static MOUSE_BTNS: [&str; 20] = [
     "BTN_TASK",
 ];
 
-thread_local! {
-    static DEVICE_NAME: RefCell<Option<String>> = RefCell::new(None);
-}
+static mut DEVICE_NAME: Option<String> = None;
 
 // Credit: https://github.com/mooz/xkeysnail/blob/bf3c93b4fe6efd42893db4e6588e5ef1c4909cfb/xkeysnail/output.py#L10-L32
 pub fn output_device(bus_type: Option<BusType>, enable_wheel: bool) -> Result<VirtualDevice, Box<dyn Error>> {
@@ -257,20 +254,18 @@ impl InputDevice {
         }))
     }
 
-    fn current_name() -> String {
-        DEVICE_NAME.with_borrow_mut(|value| {
-            if value.is_none() {
-                let device_name = if Self::has_device_name("xremap") {
-                    format!("xremap pid={}", process::id())
-                } else {
-                    "xremap".to_string()
-                };
-
-                (*value) = Some(device_name);
+    fn current_name() -> &'static str {
+        if unsafe { DEVICE_NAME.is_none() } {
+            let device_name = if Self::has_device_name("xremap") {
+                format!("xremap pid={}", process::id())
+            } else {
+                "xremap".to_string()
             };
-
-            value.clone().unwrap()
-        })
+            unsafe {
+                DEVICE_NAME = Some(device_name);
+            }
+        }
+        unsafe { DEVICE_NAME.as_ref() }.unwrap()
     }
 
     fn has_device_name(device_name: &str) -> bool {

--- a/src/device.rs
+++ b/src/device.rs
@@ -254,6 +254,7 @@ impl InputDevice {
         }))
     }
 
+    #[allow(static_mut_refs)]
     fn current_name() -> &'static str {
         if unsafe { DEVICE_NAME.is_none() } {
             let device_name = if Self::has_device_name("xremap") {


### PR DESCRIPTION
Rust warns about static_mut_refs in device.rs. Info: [https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html)

This PR fixes this warning by creating a thread local variable for `DEVICE_NAME`. This is possible because `current_name` is ever only called from the main thread.