### PR TITLE
Allowing matching event device on udev properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,30 @@ jobs:
           name: xremap-${{ matrix.arch }}-${{ matrix.feature }}
           path: target/${{ matrix.arch }}-unknown-linux-musl/release/xremap-linux-${{ matrix.arch }}-${{ matrix.feature }}.zip
 
+  build-libc:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        feature: [udev]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: x86_64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ubuntu-latest-glibc-${{ matrix.feature }}
+
+      - name: Install libudev dependencies
+        run: sudo apt-get update && sudo apt-get -y install pkg-config libudev1 libudev-dev
+
+      - name: Build
+        run: cargo build --release --features ${{ matrix.feature }}
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1580,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "udev"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f"
+dependencies = [
+ "io-lifetimes",
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +1921,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "toml 0.8.15",
+ "udev",
  "wayland-client",
  "wayland-protocols-wlr",
  "x11rb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ x11rb = { version = "0.13.1", optional = true }
 zbus = { version = "1.9.2", optional = true }
 hyprland = { version = "0.3.13", optional = true }
 toml = "0.8.15"
+udev = { version = "0.9.3", optional = true }
 
 [features]
 gnome = ["zbus"]
@@ -37,6 +38,7 @@ x11 = ["x11rb"]
 hypr = ["hyprland"]
 kde = ["zbus"]
 wlroots = ["wayland-client", "wayland-protocols-wlr"]
+udev = ["dep:udev"]
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
This is a follow-up of PR584. When the device IDs are not known, it's still
possible to match them if they are sharing a common udev property (as shown with
``udevadm info /dev/input/eventX``).

So, add the udev crate and use it to get the device property to match.
Given that it may not be desirable for everyone, this has been put
inside a feature. Moreover, this will avoid build issues in the CI,
due to the musl toolchain missing the udev development files.
