### PR TITLE
Fixes --watch=config causing xremap to crash when certain text editors save the config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -198,7 +198,11 @@ fn main() -> anyhow::Result<()> {
                         .flatten()
                         .max(),
                 ) {
-                    (Some(last_mtime), Some(current_mtim)) if last_mtime == current_mtim => continue,
+                    (Some(last_mtime), Some(current_mtim)) if last_mtime == current_mtim => {
+                        if let Ok(c) = load_configs(&config_paths) {
+                            config = c;
+                        }
+                    },
                     _ => {
                         if let Ok(c) = load_configs(&config_paths) {
                             println!("Reloading Config");


### PR DESCRIPTION
This fixes the issue discussed in [ --watch=config Reloading Config causes key mapping to stop working #617 ](https://github.com/xremap/xremap/discussions/617)

_Mostly_ Copy pasta from my comment in the discussion:

Certain editors when saving a file will first erase all the data in the file, then write the contents to the file, then close the file. This would not be an issue if one of two things were the case:

1. We did not check if the current last modified time is the same as the one when we last updated the config file to see if we should update the config
2. Linux updated the last modified time on the second write.

Currently we are checking, and I remember reading somewhere (probably in man7.org, but I can't find it anymore), that Linux may not update the modified time on writes close together in time (if I remember correctly it may have to do with clock granularity that the system uses for this function and is system dependent); and this appears to be happening in this case.

So what is happening is:

1. Editor truncates file
2. Modified time is updated on file
3. Modify event generated
4. Receive Modify event
5. Modify time is different from one on hand, so we will update config
6. Update config (Which will now be empty due to data being erased in the file)
7. Editor writes data in file
8. Modify time is NOT updated on file
9. Modify event generated
10. Receive modify event
11. Modify time is same on hand, so we do not update config
12. Editor closes the file
13. We are left with an empty config and the mapper stops working

Since this appears to be a bug in Linux that the modified time is not updated on "close in time" writes, I recommend we stop checking if the modified time is the same on hand and just update the config no matter what. We can however leave the time check to gate-keep the println statement of "Reloading Config" so the user doesn't see it twice for one save event.

This bug will not appear for all editors used to save the config file, as different editors take different approaches in saving files. I was able to reproduce this bug using VSCode to save my config file. Even in VSCode this bug also may not show up all the time as the Linux modified time bug does not appear to happen all the time.