### PR TITLE
fmt on clean files in master

### DIFF
--- a/src/action_dispatcher.rs
+++ b/src/action_dispatcher.rs
@@ -94,7 +94,7 @@ impl ActionDispatcher {
             self.sigaction_set = true;
         }
 
-        debug!("Running command: {:?}", command);
+        debug!("Running command: {command:?}");
         match fork() {
             Ok(Fork::Child) => {
                 // Child process should fork again, and the parent should exit 0, while the child
@@ -114,21 +114,21 @@ impl ActionDispatcher {
                                 exit(0);
                             }
                             Err(e) => {
-                                error!("Error running command: {:?}", e);
+                                error!("Error running command: {e:?}");
                                 exit(1);
                             }
                         }
                     }
                     Ok(Fork::Parent(_)) => exit(0),
                     Err(e) => {
-                        error!("Error spawning process: {:?}", e);
+                        error!("Error spawning process: {e:?}");
                         exit(1);
                     }
                 }
             }
             // Parent should simply continue.
             Ok(Fork::Parent(_)) => (),
-            Err(e) => error!("Error spawning process: {:?}", e),
+            Err(e) => error!("Error spawning process: {e:?}"),
         }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -36,7 +36,7 @@ impl WMClient {
         if let Some(window) = &result {
             if &self.last_window != window {
                 self.last_window = window.clone();
-                println!("window: {}", window);
+                println!("window: {window}");
             }
         }
         result
@@ -56,7 +56,7 @@ impl WMClient {
         if let Some(application) = &result {
             if &self.last_application != application {
                 self.last_application = application.clone();
-                println!("application: {}", application);
+                println!("application: {application}");
             }
         }
         result

--- a/src/config/key.rs
+++ b/src/config/key.rs
@@ -22,7 +22,7 @@ pub fn parse_key(input: &str) -> Result<Key, Box<dyn Error>> {
     }
 
     // You can abbreviate "KEY_" of any "KEY_*" scancodes.
-    if let Ok(key) = Key::from_str(&format!("KEY_{}", name)) {
+    if let Ok(key) = Key::from_str(&format!("KEY_{name}")) {
         return Ok(key);
     }
 
@@ -129,5 +129,5 @@ pub fn parse_key(input: &str) -> Result<Key, Box<dyn Error>> {
         return Ok(key);
     }
 
-    return Err(format!("unknown key '{}'", input).into());
+    Err(format!("unknown key '{input}'").into())
 }

--- a/src/config/key_press.rs
+++ b/src/config/key_press.rs
@@ -46,7 +46,7 @@ fn parse_key_press(input: &str) -> Result<KeyPress, Box<dyn error::Error>> {
             modifiers,
         })
     } else {
-        Err(format!("empty key_press: {}", input).into())
+        Err(format!("empty key_press: {input}").into())
     }
 }
 
@@ -67,6 +67,6 @@ fn parse_modifier(modifier: &str) -> Result<Modifier, Box<dyn Error>> {
         "WIN" => Ok(Modifier::Windows),
         "WINDOWS" => Ok(Modifier::Windows),
         // else
-        key => parse_key(key).map(|key| Modifier::Key(key)),
+        key => parse_key(key).map(Modifier::Key),
     }
 }

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -76,7 +76,7 @@ pub fn build_keymap_table(keymaps: &Vec<Keymap>) -> HashMap<Key, Vec<KeymapEntry
             table.insert(key_press.key, entries);
         }
     }
-    return table;
+    table
 }
 
 // Subset of KeymapEntry for override_remap
@@ -105,5 +105,5 @@ pub fn build_override_table(
         });
         table.insert(key_press.key, entries);
     }
-    return table;
+    table
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -84,8 +84,8 @@ pub fn load_configs(filenames: &Vec<PathBuf>) -> Result<Config, Box<dyn error::E
     };
 
     for filename in &filenames[1..] {
-        let config_contents = fs::read_to_string(&filename)?;
-        let c: Config = match get_file_ext(&filename) {
+        let config_contents = fs::read_to_string(filename)?;
+        let c: Config = match get_file_ext(filename) {
             ConfigFiletype::Yaml => serde_yaml::from_str(&config_contents)?,
             ConfigFiletype::Toml => toml::from_str(&config_contents)?,
         };
@@ -133,7 +133,7 @@ where
     for key_str in key_strs {
         keys.push(parse_key(&key_str).map_err(serde::de::Error::custom)?);
     }
-    return Ok(keys);
+    Ok(keys)
 }
 
 fn const_true() -> bool {

--- a/src/config/modmap_action.rs
+++ b/src/config/modmap_action.rs
@@ -64,7 +64,7 @@ where
     D: Deserializer<'de>,
 {
     let actions = Actions::deserialize(deserializer)?;
-    return Ok(actions.into_vec());
+    Ok(actions.into_vec())
 }
 
 fn default_alone_timeout() -> Duration {

--- a/src/device.rs
+++ b/src/device.rs
@@ -56,7 +56,7 @@ pub fn output_device(
     let mut keys: AttributeSet<Key> = AttributeSet::new();
     for code in Key::KEY_RESERVED.code()..Key::BTN_TRIGGER_HAPPY40.code() {
         let key = Key::new(code);
-        let name = format!("{:?}", key);
+        let name = format!("{key:?}");
         if name.starts_with("KEY_") || MOUSE_BTNS.contains(&&*name) {
             keys.insert(key);
         }
@@ -101,9 +101,9 @@ pub fn get_input_devices(
     devices.sort();
 
     println!("Selecting devices from the following list:");
-    println!("{}", SEPARATOR);
+    println!("{SEPARATOR}");
     devices.iter().for_each(InputDevice::print);
-    println!("{}", SEPARATOR);
+    println!("{SEPARATOR}");
 
     if device_opts.is_empty() {
         if mouse {
@@ -112,12 +112,12 @@ pub fn get_input_devices(
             print!("Selected keyboards automatically since --device options weren't specified");
         }
     } else {
-        print!("Selected devices matching {:?}", device_opts);
+        print!("Selected devices matching {device_opts:?}");
     };
     if ignore_opts.is_empty() {
         println!(":")
     } else {
-        println!(", ignoring {:?}:", ignore_opts);
+        println!(", ignoring {ignore_opts:?}:");
     }
 
     let devices: Vec<_> = devices
@@ -126,11 +126,11 @@ pub fn get_input_devices(
         // alternative is `Vec::retain_mut` whenever that gets stabilized
         .filter_map(|mut device| {
             // filter out any not matching devices and devices that error on grab
-            (device.is_input_device(device_opts, ignore_opts, mouse) && device.grab()).then(|| device)
+            (device.is_input_device(device_opts, ignore_opts, mouse) && device.grab()).then_some(device)
         })
         .collect();
 
-    println!("{}", SEPARATOR);
+    println!("{SEPARATOR}");
     if devices.is_empty() {
         if watch {
             println!("warning: No device was selected, but --watch is waiting for new devices.");
@@ -140,7 +140,7 @@ pub fn get_input_devices(
     } else {
         devices.iter().for_each(InputDevice::print);
     }
-    println!("{}", SEPARATOR);
+    println!("{SEPARATOR}");
 
     Ok(devices.into_iter().map(From::from).collect())
 }
@@ -213,7 +213,7 @@ impl<'a> InputDeviceInfo<'a> {
                 }
             }
         }
-        return false;
+        false
     }
 }
 
@@ -343,9 +343,7 @@ impl InputDevice {
             Ok(devices) => devices.collect(),
             Err(_) => return true, // fallback to the safe side
         };
-        devices
-            .iter()
-            .any(|device| return device.device_name().contains(device_name))
+        devices.iter().any(|device| device.device_name().contains(device_name))
     }
 
     fn matches_any(&self, filter: &[String]) -> bool {
@@ -353,7 +351,7 @@ impl InputDevice {
         if self.device_name() == Self::current_name() {
             return false;
         }
-        return filter.iter().any(|f| self.to_info().matches(f));
+        filter.iter().any(|f| self.to_info().matches(f))
     }
 
     fn is_keyboard(&self) -> bool {
@@ -372,7 +370,7 @@ impl InputDevice {
         }
         self.device
             .supported_keys()
-            .map_or(false, |keys| keys.contains(Key::BTN_LEFT))
+            .is_some_and(|keys| keys.contains(Key::BTN_LEFT))
     }
 
     pub fn print(&self) {

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -348,15 +348,21 @@ impl EventHandler {
                 // Just hook actions, and then emit the original event. We might want to
                 // support reordering the key event and dispatched actions later.
                 self.dispatch_actions(
-                    &(if value == PRESS { press } else if value == RELEASE { release } else { repeat })
-                        .into_iter()
-                        .map(|action| TaggedAction {
-                            action,
-                            exact_match: false,
-                        })
-                        .collect(),
+                    &(if value == PRESS {
+                        press
+                    } else if value == RELEASE {
+                        release
+                    } else {
+                        repeat
+                    })
+                    .into_iter()
+                    .map(|action| TaggedAction {
+                        action,
+                        exact_match: false,
+                    })
+                    .collect(),
                     &key,
-                )?;                
+                )?;
 
                 if skip_key_event {
                     // Do not dispatch the original key

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ fn main() -> anyhow::Result<()> {
         configs,
         completions,
         product,
-        vendor
+        vendor,
     } = Args::parse();
 
     if let Some(shell) = completions {
@@ -130,11 +130,15 @@ fn main() -> anyhow::Result<()> {
     let mut handler = EventHandler::new(timer, &config.default_mode, delay, build_client());
     let vendor = u16::from_str_radix(vendor.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x1234);
     let product = u16::from_str_radix(product.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x5678);
-    let output_device =
-        match output_device(input_devices.values().next().map(InputDevice::bus_type), config.enable_wheel, vendor, product) {
-            Ok(output_device) => output_device,
-            Err(e) => bail!("Failed to prepare an output device: {}", e),
-        };
+    let output_device = match output_device(
+        input_devices.values().next().map(InputDevice::bus_type),
+        config.enable_wheel,
+        vendor,
+        product,
+    ) {
+        Ok(output_device) => output_device,
+        Err(e) => bail!("Failed to prepare an output device: {}", e),
+    };
     let mut dispatcher = ActionDispatcher::new(output_device);
 
     // Main loop
@@ -287,7 +291,10 @@ fn handle_config_changes(
 ) -> anyhow::Result<bool> {
     //Re-add AddWatchFlags if config file has been deleted then recreated or overwritten by renaming another file to its own name
     for event in &events {
-        if event.mask.intersects(AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO) {
+        if event
+            .mask
+            .intersects(AddWatchFlags::IN_CREATE | AddWatchFlags::IN_MOVED_TO)
+        {
             for config_path in config_paths {
                 if config_path.file_name().unwrap_or_default() == event.name.clone().unwrap_or_default() {
                     inotify.add_watch(config_path, AddWatchFlags::IN_MODIFY)?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,7 +35,7 @@ impl Client for StaticClient {
 fn get_input_device_info<'a>() -> InputDeviceInfo<'a> {
     InputDeviceInfo {
         name: "Some Device",
-        path: &Path::new("/dev/input/event0"),
+        path: Path::new("/dev/input/event0"),
         vendor: 0x1234,
         product: 0x5678,
     }
@@ -194,12 +194,12 @@ fn test_cursor_behavior_1() {
     // Setup to be able to send events
     let mut input_devices = match get_input_devices(&[String::from("/dev/input/event25")], &[], true, false) {
         Ok(input_devices) => input_devices,
-        Err(e) => panic!("Failed to prepare input devices: {}", e),
+        Err(e) => panic!("Failed to prepare input devices: {e}"),
     };
     let mut output_device =
         match output_device(input_devices.values().next().map(InputDevice::bus_type), true, 0x1234, 0x5678) {
             Ok(output_device) => output_device,
-            Err(e) => panic!("Failed to prepare an output device: {}", e),
+            Err(e) => panic!("Failed to prepare an output device: {e}"),
         };
     for input_device in input_devices.values_mut() {
         let _unused = input_device.fetch_events().unwrap();
@@ -235,12 +235,12 @@ fn test_cursor_behavior_2() {
     // Setup to be able to send events
     let mut input_devices = match get_input_devices(&[String::from("/dev/input/event25")], &[], true, false) {
         Ok(input_devices) => input_devices,
-        Err(e) => panic!("Failed to prepare input devices: {}", e),
+        Err(e) => panic!("Failed to prepare input devices: {e}"),
     };
     let mut output_device =
         match output_device(input_devices.values().next().map(InputDevice::bus_type), true, 0x1234, 0x5678) {
             Ok(output_device) => output_device,
-            Err(e) => panic!("Failed to prepare an output device: {}", e),
+            Err(e) => panic!("Failed to prepare an output device: {e}"),
         };
     for input_device in input_devices.values_mut() {
         let _unused = input_device.fetch_events().unwrap();
@@ -500,7 +500,7 @@ fn test_device_override() {
         vec![Event::KeyEvent(
             InputDeviceInfo {
                 name: "Some Device",
-                path: &Path::new("/dev/input/event0"),
+                path: Path::new("/dev/input/event0"),
                 vendor: 0x1234,
                 product: 0x5678,
             },
@@ -521,7 +521,7 @@ fn test_device_override() {
         vec![Event::KeyEvent(
             InputDeviceInfo {
                 name: "Other Device",
-                path: &Path::new("/dev/input/event1"),
+                path: Path::new("/dev/input/event1"),
                 vendor: 0x1234,
                 product: 0x5678,
             },
@@ -799,5 +799,5 @@ fn assert_actions_with_current_application(
 
     actual.append(&mut event_handler.on_events(&events, &config).unwrap());
 
-    assert_eq!(format!("{:?}", actions), format!("{:?}", actual));
+    assert_eq!(format!("{actions:?}"), format!("{:?}", actual));
 }


### PR DESCRIPTION
Just running fmt on `src/` on latest `stable` (`1.8.0-stable (6b00bc3880 2025-06-23)
`). 
The reason is I'm working on [this feat branch](https://github.com/prime-run/xremap/tree/false-timeout) + some bug fixes and `diffs` could get confusing.
 
And I don't think there is a reason for bypassing current `rustfmt.toml` in the repo.

Anyways, you don't have to merge this ofcourse but it would be great if you could just fomat these files. 
(surprisingly, they blame alot of commits! eg: 5f95ec41 Arnaud Patard (2025-02-23 23:46) and cd6041b6 Arnaud Patard (2025-02-27 09:56) just to name a few)
