### PR TITLE
Code cleanups, refactors, bug fixes, optimizations and new `free_hold` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,9 +277,27 @@ sudo RUST_LOG=debug xremap config.yml
 
 Then press the key you want to know the name of.
 
-If you specify a map containing `held` and `alone`, you can use the key for two purposes.
-The key is considered `alone` if it's pressed and released within `alone_timeout_millis` (default: 1000)
-before any other key is pressed. Otherwise it's considered `held`.
+If you specify a map containing `held` and `alone`, you can use the key for two purposes. By default, the behavior is determined by a timeout:
+- If the key is pressed and released within `alone_timeout_millis` (default: 1000) without any other key being pressed, it's considered `alone`.
+- If the key is held down longer than the timeout, it's considered `held`.
+
+This can be problematic if you want to use a key as a modifier, as you might trigger the `held` action by simply holding the key for too long.
+
+The `free_hold: true` option provides a different behavior for these multi-purpose keys. When enabled:
+- The `held` action is *only* triggered when another key is pressed while the multi-purpose key is being held down. The timeout is ignored for the `held` action.
+- If the key is released without any other key being pressed, it triggers the `alone` action, regardless of how long it was held.
+
+This allows a key to be held indefinitely without triggering its `held` state, which is ideal for keys that also serve as modifiers. For example, you can make the `Space` key act as `Shift` when held and combined with another key, but still type a regular `Space` when tapped.
+
+```yml
+modmap:
+  - name: Space as Shift
+    remap:
+      Space:
+        held: Shift_L
+        alone: Space
+        free_hold: true
+```
 
 ### keymap
 

--- a/src/config/modmap_action.rs
+++ b/src/config/modmap_action.rs
@@ -27,6 +27,8 @@ pub struct MultiPurposeKey {
     #[serde_as(as = "DurationMilliSeconds")]
     #[serde(default = "default_alone_timeout", rename = "alone_timeout_millis")]
     pub alone_timeout: Duration,
+    #[serde(default = "default_tap_hold_without_timeout")]
+    pub tap_hold_without_timeout: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -69,4 +71,9 @@ where
 
 fn default_alone_timeout() -> Duration {
     Duration::from_millis(1000)
+}
+
+fn default_tap_hold_without_timeout() -> bool {
+    false // NOTE: should default to true ?!
+          // up to maintainer
 }

--- a/src/config/modmap_action.rs
+++ b/src/config/modmap_action.rs
@@ -27,8 +27,8 @@ pub struct MultiPurposeKey {
     #[serde_as(as = "DurationMilliSeconds")]
     #[serde(default = "default_alone_timeout", rename = "alone_timeout_millis")]
     pub alone_timeout: Duration,
-    #[serde(default = "default_tap_hold_without_timeout")]
-    pub tap_hold_without_timeout: bool,
+    #[serde(default = "default_free_hold")]
+    pub free_hold: bool,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -73,7 +73,7 @@ fn default_alone_timeout() -> Duration {
     Duration::from_millis(1000)
 }
 
-fn default_tap_hold_without_timeout() -> bool {
+fn default_free_hold() -> bool {
     false // NOTE: should default to true ?!
           // up to maintainer
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -75,7 +75,7 @@ fn test_yaml_modmap_multi_purpose_key_without_timeout() {
           Space:
             held: Shift_L
             alone: Space
-            tap_hold_without_timeout: true
+            free_hold: true
     "})
     // NOTE: add edge cases tests for when timeout = default
 }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -68,6 +68,19 @@ fn test_yaml_modmap_multi_purpose_key() {
     "})
 }
 #[test]
+fn test_yaml_modmap_multi_purpose_key_without_timeout() {
+    yaml_assert_parse(indoc! {"
+    modmap:
+      - remap:
+          Space:
+            held: Shift_L
+            alone: Space
+            tap_hold_without_timeout: true
+    "})
+    // NOTE: add edge cases tests for when timeout = default
+}
+
+#[test]
 fn test_yaml_modmap_multi_purpose_key_multi_key() {
     yaml_assert_parse(indoc! {"
     modmap:

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -284,7 +284,7 @@ impl EventHandler {
     }
 
     // Repeat/Release what's originally pressed even if remapping changes while holding it
-    fn maintain_pressed_keys(&mut self, key: Key, value: i32, events: &mut Vec<(Key, i32)>) {
+    fn maintain_pressed_keys(&mut self, key: Key, value: i32, events: &mut [(Key, i32)]) {
         // Not handling multi-purpose keysfor now; too complicated
         if events.len() != 1 || value != events[0].1 {
             return;
@@ -623,7 +623,7 @@ impl EventHandler {
     }
 
     // Return (extra_modifiers, missing_modifiers)
-    fn diff_modifiers(&self, modifiers: &Vec<Modifier>) -> (Vec<Key>, Vec<Key>) {
+    fn diff_modifiers(&self, modifiers: &[Modifier]) -> (Vec<Key>, Vec<Key>) {
         let extra_modifiers: Vec<Key> = self
             .modifiers
             .iter()
@@ -723,7 +723,7 @@ impl EventHandler {
     }
 }
 
-fn is_remap(actions: &Vec<KeymapAction>) -> bool {
+fn is_remap(actions: &[KeymapAction]) -> bool {
     if actions.is_empty() {
         // When actions is empty it could either be regarded as an empty remap
         //  or no actions. In principle that shouldn't matter, but remap is
@@ -740,16 +740,12 @@ fn is_remap(actions: &Vec<KeymapAction>) -> bool {
     })
 }
 
-fn with_extra_modifiers(
-    actions: &Vec<KeymapAction>,
-    extra_modifiers: &Vec<Key>,
-    exact_match: bool,
-) -> Vec<TaggedAction> {
+fn with_extra_modifiers(actions: &[KeymapAction], extra_modifiers: &[Key], exact_match: bool) -> Vec<TaggedAction> {
     let mut result: Vec<TaggedAction> = vec![];
     if !extra_modifiers.is_empty() {
         // Virtually release extra modifiers so that they won't be physically released on KeyPress
         result.push(TaggedAction {
-            action: KeymapAction::SetExtraModifiers(extra_modifiers.clone()),
+            action: KeymapAction::SetExtraModifiers(extra_modifiers.to_vec()),
             exact_match,
         });
     }
@@ -767,7 +763,7 @@ fn with_extra_modifiers(
     result
 }
 
-fn contains_modifier(modifiers: &Vec<Modifier>, key: &Key) -> bool {
+fn contains_modifier(modifiers: &[Modifier], key: &Key) -> bool {
     for modifier in modifiers {
         if match modifier {
             Modifier::Shift => key == &Key::KEY_LEFTSHIFT || key == &Key::KEY_RIGHTSHIFT,

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -396,6 +396,17 @@ impl EventHandler {
             for (_, state) in self.multi_purpose_keys.iter_mut() {
                 flushed.extend(state.force_held());
             }
+
+            // filter out key presses that are part of the flushed events
+            let flushed_presses: HashSet<Key> = flushed
+                .iter()
+                .filter_map(|(k, v)| (*v == PRESS).then_some(*k))
+                .collect();
+            let key_values: Vec<(Key, i32)> = key_values
+                .into_iter()
+                .filter(|(key, value)| !(*value == PRESS && flushed_presses.contains(key)))
+                .collect();
+
             flushed.extend(key_values);
             flushed
         } else {
@@ -868,7 +879,7 @@ impl MultiPurposeKeyState {
 
         if press {
             let mut keys = self.held.clone().into_vec();
-            keys.sort_by(modifiers_last);
+            keys.sort_by(modifiers_first);
             keys.into_iter().map(|key| (key, PRESS)).collect()
         } else {
             vec![]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -315,7 +315,7 @@ impl EventHandler {
                 held,
                 alone,
                 alone_timeout,
-                tap_hold_without_timeout, //FIX: it's just a bad name!
+                free_hold,
             }) => {
                 match value {
                     PRESS => {
@@ -324,7 +324,7 @@ impl EventHandler {
                             MultiPurposeKeyState {
                                 held,
                                 alone,
-                                alone_timeout_at: if tap_hold_without_timeout {
+                                alone_timeout_at: if free_hold {
                                     None
                                 } else {
                                     Some(Instant::now() + alone_timeout)
@@ -734,10 +734,7 @@ fn is_remap(actions: &[KeymapAction]) -> bool {
         return false;
     }
 
-    actions.iter().all(|x| match x {
-        KeymapAction::Remap(..) => true,
-        _ => false,
-    })
+    actions.iter().all(|x| matches!(x, KeymapAction::Remap(..)))
 }
 
 fn with_extra_modifiers(actions: &[KeymapAction], extra_modifiers: &[Key], exact_match: bool) -> Vec<TaggedAction> {


### PR DESCRIPTION
  This PR:

Adds new feature: 


   - `config`: Add `free_hold` option for multi-purpose keys
     - A new boolean option, free_hold, has been added to the multi-purpose key configuration.
     - When free_hold: true, the held action is only triggered after another key is pressed, rather than after a timeout. This allows a key to be held
       indefinitely without triggering its "held" state, which is ideal for keys that also serve as modifiers.


Fixes:

   - `event-handler`: Prevent duplicate key presses when held by reordering dispatchers
     - The event handler now correctly filters out redundant key presses that are already part of a flushed event queue.

Refactors:
   - `event-handler` : Improve `MultiPurposeKeyState` logic
     - The internal state management for multi-purpose keys has been significantly refactored for better readability and robustness. Complex conditional
       logic has been simplified into more straightforward, pattern-matching-based structures.


   - `event-handler` : Streamline `dispatch_keys` method
     - The `dispatch_keys` method in the event handler has been refactored to be more concise and efficient, improving the overall clarity of the
       event-handling pipeline.

Optimizes: 

   - `event-handler`: Use ***slices for more idiomatic arguments***
     - `Vec<T>` -> `&[T]` for fn args. This avoids unnecessary allocations and provides more flexibility to the caller.


   - Minor code cleanup
     - Removed a redundant conditional check against `true` , simplifying the logic for handling relative mouse events. (Update: reverted due to failing tests)



