### PR TITLE
Implement Held Threshold and rename Alone to Tap

### DIFF
--- a/src/config/modmap_action.rs
+++ b/src/config/modmap_action.rs
@@ -23,10 +23,13 @@ pub enum ModmapAction {
 #[derive(Clone, Debug, Deserialize)]
 pub struct MultiPurposeKey {
     pub held: Keys,
-    pub alone: Keys,
     #[serde_as(as = "DurationMilliSeconds")]
-    #[serde(default = "default_alone_timeout", rename = "alone_timeout_millis")]
-    pub alone_timeout: Duration,
+    #[serde(default = "default_held_threshold", rename = "held_threshold_millis")]
+    pub held_threshold: Duration,
+    pub tap: Keys,
+    #[serde_as(as = "DurationMilliSeconds")]
+    #[serde(default = "default_tap_timeout", rename = "tap_timeout_millis")]
+    pub tap_timeout: Duration,
     #[serde(default = "default_free_hold")]
     pub free_hold: bool,
 }
@@ -69,8 +72,12 @@ where
     Ok(actions.into_vec())
 }
 
-fn default_alone_timeout() -> Duration {
+fn default_tap_timeout() -> Duration {
     Duration::from_millis(1000)
+}
+
+fn default_held_threshold() -> Duration {
+    Duration::from_millis(0)
 }
 
 fn default_free_hold() -> bool {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -59,12 +59,12 @@ fn test_yaml_modmap_multi_purpose_key() {
       - remap:
           Space:
             held: Shift_L
-            alone: Space
+            tap: Space
       - remap:
           Muhenkan:
             held: Alt_L
-            alone: Muhenkan
-            alone_timeout_millis: 500
+            tap: Muhenkan
+            tap_timeout_millis: 500
     "})
 }
 #[test]
@@ -74,7 +74,7 @@ fn test_yaml_modmap_multi_purpose_key_without_timeout() {
       - remap:
           Space:
             held: Shift_L
-            alone: Space
+            tap: Space
             free_hold: true
     "})
     // NOTE: add edge cases tests for when timeout = default
@@ -87,12 +87,12 @@ fn test_yaml_modmap_multi_purpose_key_multi_key() {
       - remap:
           Space:
             held: [Shift_L]
-            alone: [Shift_L,A]
+            tap: [Shift_L,A]
       - remap:
           Muhenkan:
             held: [Alt_L,Shift_L]
-            alone: [Muhenkan]
-            alone_timeout_millis: 500
+            tap: [Muhenkan]
+            tap_timeout_millis: 500
     "})
 }
 #[test]
@@ -358,13 +358,13 @@ fn test_toml_modmap_multi_purpose_key() {
     [[modmap]]
     [modmap.remap.Space]
     held = [ \"Shift_L\" ]
-    alone = \"Space\"
+    tap = \"Space\"
 
     [[modmap]]
     [modmap.remap.Muhenkan]
     held = [ \"Alt_L\", \"Shift_L\" ]
-    alone = [ \"Muhenkan\" ]
-    alone_timeout_millis = 500
+    tap = [ \"Muhenkan\" ]
+    tap_timeout_millis = 500
     "})
 }
 
@@ -374,13 +374,13 @@ fn test_toml_modmap_multi_purpose_key_multi_key() {
     [[modmap]]
     [modmap.remap.Space]
     held = [ \"Shift_L\" ]
-    alone = [ \"Shift_L\", \"A\" ]
+    tap = [ \"Shift_L\", \"A\" ]
 
     [[modmap]]
     [modmap.remap.Muhenkan]
     held = [ \"Alt_L\", \"Shift_L\" ]
-    alone = [ \"Muhenkan\" ]
-    alone_timeout_millis = 500
+    tap = [ \"Muhenkan\" ]
+    tap_timeout_millis = 500
     "})
 }
 #[test]

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -852,21 +852,14 @@ impl MultiPurposeKeyState {
 
     fn release(&self) -> Vec<(Key, i32)> {
         match self.tap_timeout_at {
-            Some(tap_timeout_at) if Instant::now() < tap_timeout_at => {
-                debug!("Release match Some(tap) : {:?}", self);
-                self.press_and_release(&self.tap)
-            }
+            Some(tap_timeout_at) if Instant::now() < tap_timeout_at => self.press_and_release(&self.tap),
             Some(_) | None => match self.held_down {
                 true => {
-                    debug!("Release match None true : {:?}", self);
                     let mut release_keys = self.held.clone().into_vec();
                     release_keys.sort_by(modifiers_last);
                     release_keys.into_iter().map(|key| (key, RELEASE)).collect()
                 }
-                false => {
-                    debug!("Release match None false : {:?}", self);
-                    self.press_and_release(&self.tap)
-                }
+                false => self.press_and_release(&self.tap),
             },
         }
     }


### PR DESCRIPTION
## Summary

This PR attempts to implement the behavior proposed in #614, extending the tap/hold options for more flexible multi-purpose key handling.

## New Behavior

A key now transitions through distinct states based on timing and whether another key is pressed:

**Key behavior:**
- **Before `held_threshold_millis`:**  
  - If released alone → **tap**  
  - If another key is pressed → **tap**
  
- **After `held_threshold_millis` and before `tap_timeout_millis`:**
  - If another key is pressed → **held**
  - If released alone → **tap**

- **After `tap_timeout_millis`:**  
  - Always **held**

The default held_threshold_millis is set to `0`.
## Potential Bug Fix

This also appears to fix a bug that exists in the current `master` branch but was not present in version `0.10.11` (which I had previously installed). The issue occurs with modifier-tap keys (e.g. tap = `SHIFT_L`, hold = `CTRL_L`):

Typing quickly (e.g. "SHIFT, S") could cause the key to send `CTRL_L + S`, but incorrectly leave `CTRL_L` held even after release, since the release event was processed as `SHIFT_L`.

## Notes

- I adopted the naming (`held`, `held_threshold_millis`, `tap`, `tap_timeout_millis`) based on the discussion. This may break backward compatibility, and I can rename it if needed.
- I’ve tested a few configurations and they behaved as I expected, but I haven’t written formal tests. If tests are required, I’d be happy to look into it and would appreciate some guidance on how to proceed.
- I'm fairly new to open source development, so if I’ve done anything incorrectly (in code, structure, or process) I apologize and welcome any feedback or corrections.
- Let me know if anything else should be changed.

Best regards,  
**Trädgårdsmästaren**
