### PR TITLE
Add Niri client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, aarch64]
-        feature: [x11, gnome, kde, hypr, wlroots]
+        feature: [x11, gnome, kde, hypr, wlroots, niri]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -107,6 +107,7 @@ jobs:
       - { uses: actions/download-artifact@v4, with: { name: xremap-x86_64-kde,     path: package/ } }
       - { uses: actions/download-artifact@v4, with: { name: xremap-x86_64-hypr,    path: package/ } }
       - { uses: actions/download-artifact@v4, with: { name: xremap-x86_64-wlroots, path: package/ } }
+      - { uses: actions/download-artifact@v4, with: { name: xremap-x86_64-niri,    path: package/ } }
 
       # Fetch aarch64 binary
       - { uses: actions/download-artifact@v4, with: { name: xremap-aarch64-x11,     path: package/ } }
@@ -114,6 +115,7 @@ jobs:
       - { uses: actions/download-artifact@v4, with: { name: xremap-aarch64-kde,     path: package/ } }
       - { uses: actions/download-artifact@v4, with: { name: xremap-aarch64-hypr,    path: package/ } }
       - { uses: actions/download-artifact@v4, with: { name: xremap-aarch64-wlroots, path: package/ } }
+      - { uses: actions/download-artifact@v4, with: { name: xremap-aarch64-niri,    path: package/ } }
 
       # Release binary
       - name: Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "niri-ipc"
+version = "25.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3e165f7854b2f83054a2e8f7024baa49666ad25cdb95b8fb9fd17c48045605"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2097,7 @@ dependencies = [
  "indoc",
  "lazy_static",
  "log",
+ "niri-ipc",
  "nix 0.26.2",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ indoc = "2.0"
 lazy_static = "1.5.0"
 log = "0.4.27"
 nix = "0.26.2"
+niri-ipc = { version = "25.5.1", optional = true }
 regex = "1.11.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -40,6 +41,7 @@ hypr = ["hyprland"]
 kde = ["zbus"]
 wlroots = ["wayland-client", "wayland-protocols-wlr"]
 udev = ["dep:udev"]
+niri = ["niri-ipc"]
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ cargo install xremap --features gnome   # GNOME Wayland
 cargo install xremap --features kde     # KDE-Plasma Wayland
 cargo install xremap --features wlroots # Sway, Wayfire, etc.
 cargo install xremap --features hypr    # Hyprland
+cargo install xremap --features niri    # Niri
 cargo install xremap                    # Others
 ```
 
@@ -197,6 +198,14 @@ Update `/usr/share/dbus-1/session.conf` as follows, and reboot your machine.
 
 Xremap cannot be run as root. Follow the instructions above to run xremap without sudo.
 
+### Niri
+
+If you use `sudo` to run `xremap`, you need to ensure that the `NIRI_SOCKET` env var is available to xremap:
+
+```bash
+sudo NIRI_SOCKET="$NIRI_SOCKET" xremap config.yml
+```
+
 ## Configuration
 
 Your `config.yml` should look like this:
@@ -249,7 +258,7 @@ modmap:
       not: [Application, ...]
       # or
       only: [Application, ...]
-    window: # Optional (only hyprland/wlroots/kde clients supported)
+    window: # Optional (only hyprland/wlroots/kde/niri clients supported)
       not: [/regex of window title/, ...]
       # or
       only: [/regex of window title/, ...]
@@ -338,7 +347,7 @@ keymap:
       not: [Application, ...]
       # or
       only: [Application, ...]
-    window: # Optional (only hyprland/wlroots/kde clients supported)
+    window: # Optional (only hyprland/wlroots/kde/niri clients supported)
       not: [/regex of window title/, ...]
       # or
       only: [/regex of window title/, ...]
@@ -431,6 +440,14 @@ swaymsg -t get_tree
 ```
 
 Locate `app_id` in the output.
+
+#### Niri
+
+```
+niri msg windows
+```
+
+Locate `App ID` in the output.
 
 #### application-specific key overrides
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -98,12 +98,20 @@ pub fn build_client() -> WMClient {
     WMClient::new("wlroots", Box::new(wlroots_client::WlRootsClient::new()))
 }
 
+#[cfg(feature = "niri")]
+mod niri_client;
+#[cfg(feature = "niri")]
+pub fn build_client() -> WMClient {
+    WMClient::new("Niri", Box::new(niri_client::NiriClient::new()))
+}
+
 #[cfg(not(any(
     feature = "gnome",
     feature = "x11",
     feature = "hypr",
     feature = "kde",
-    feature = "wlroots"
+    feature = "wlroots",
+    feature = "niri"
 )))]
 mod null_client;
 #[cfg(not(any(
@@ -111,7 +119,8 @@ mod null_client;
     feature = "x11",
     feature = "hypr",
     feature = "kde",
-    feature = "wlroots"
+    feature = "wlroots",
+    feature = "niri"
 )))]
 pub fn build_client() -> WMClient {
     WMClient::new("none", Box::new(null_client::NullClient))

--- a/src/client/niri_client.rs
+++ b/src/client/niri_client.rs
@@ -1,12 +1,12 @@
 use crate::client::Client;
-use niri_ipc::{Request, Response, socket::Socket};
+use niri_ipc::{socket::Socket, Request, Response};
 
 /// Client for the Niri scrollable Wayland compositor.
-/// 
+///
 /// Communicates with Niri via its IPC socket to determine the currently
 /// focused window and application. Requires the NIRI_SOCKET environment
 /// variable to be set, which Niri does automatically when running as a session.
-/// 
+///
 /// Note: This implementation creates a new socket connection for each query.
 /// In the future, a persistent connection might be more efficient.
 pub struct NiriClient;
@@ -15,23 +15,21 @@ impl NiriClient {
     pub fn new() -> NiriClient {
         NiriClient {}
     }
-    
+
     fn get_active_window() -> Option<niri_ipc::Window> {
         let mut socket = match Socket::connect() {
             Ok(socket) => socket,
             Err(_) => return None,
         };
-        
+
         let response = match socket.send(Request::Windows) {
             Ok(Ok(response)) => response,
             Ok(Err(_)) => return None,
             Err(_) => return None,
         };
-        
+
         match response {
-            Response::Windows(windows) => {
-                windows.into_iter().find(|w| w.is_focused)
-            }
+            Response::Windows(windows) => windows.into_iter().find(|w| w.is_focused),
             _ => None,
         }
     }
@@ -43,32 +41,27 @@ impl Client for NiriClient {
             Ok(path) => path,
             Err(_) => return false,
         };
-        
+
         if !std::path::Path::new(&socket_path).exists() {
             return false;
         }
-        
+
         // Try to actually connect to verify it works
         // This ensures we don't claim support if Niri is not responding
         Socket::connect().is_ok()
     }
-    
+
     fn current_window(&mut self) -> Option<String> {
         Self::get_active_window().and_then(|win| {
             // Prefer title, but fallback to app_id if title is not available
-            win.title.or_else(|| {
-                win.app_id.clone()
-            })
+            win.title.or_else(|| win.app_id.clone())
         })
     }
 
     fn current_application(&mut self) -> Option<String> {
         Self::get_active_window().and_then(|win| {
             // Prefer app_id, but fallback to window title if app_id is not available
-            win.app_id.or_else(|| {
-                win.title.clone()
-            })
+            win.app_id.or_else(|| win.title.clone())
         })
     }
 }
-

--- a/src/client/niri_client.rs
+++ b/src/client/niri_client.rs
@@ -1,0 +1,74 @@
+use crate::client::Client;
+use niri_ipc::{Request, Response, socket::Socket};
+
+/// Client for the Niri scrollable Wayland compositor.
+/// 
+/// Communicates with Niri via its IPC socket to determine the currently
+/// focused window and application. Requires the NIRI_SOCKET environment
+/// variable to be set, which Niri does automatically when running as a session.
+/// 
+/// Note: This implementation creates a new socket connection for each query.
+/// In the future, a persistent connection might be more efficient.
+pub struct NiriClient;
+
+impl NiriClient {
+    pub fn new() -> NiriClient {
+        NiriClient {}
+    }
+    
+    fn get_active_window() -> Option<niri_ipc::Window> {
+        let mut socket = match Socket::connect() {
+            Ok(socket) => socket,
+            Err(_) => return None,
+        };
+        
+        let response = match socket.send(Request::Windows) {
+            Ok(Ok(response)) => response,
+            Ok(Err(_)) => return None,
+            Err(_) => return None,
+        };
+        
+        match response {
+            Response::Windows(windows) => {
+                windows.into_iter().find(|w| w.is_focused)
+            }
+            _ => None,
+        }
+    }
+}
+
+impl Client for NiriClient {
+    fn supported(&mut self) -> bool {
+        let socket_path = match std::env::var("NIRI_SOCKET") {
+            Ok(path) => path,
+            Err(_) => return false,
+        };
+        
+        if !std::path::Path::new(&socket_path).exists() {
+            return false;
+        }
+        
+        // Try to actually connect to verify it works
+        // This ensures we don't claim support if Niri is not responding
+        Socket::connect().is_ok()
+    }
+    
+    fn current_window(&mut self) -> Option<String> {
+        Self::get_active_window().and_then(|win| {
+            // Prefer title, but fallback to app_id if title is not available
+            win.title.or_else(|| {
+                win.app_id.clone()
+            })
+        })
+    }
+
+    fn current_application(&mut self) -> Option<String> {
+        Self::get_active_window().and_then(|win| {
+            // Prefer app_id, but fallback to window title if app_id is not available
+            win.app_id.or_else(|| {
+                win.title.clone()
+            })
+        })
+    }
+}
+


### PR DESCRIPTION
Add a client for the [Niri](https://github.com/YaLTeR/niri) compositor to support application/window-specific remappings.

It should work as expected just like all the other WM/DE-specific plug-ins - I was able to re-use my config.yml that I used on KDE exactly as-is with Niri. I also confirmed that the `application:` and `window:` matchers both work as expected.

Notes:
- Even though I added a release matrix entry for `(aarch64, niri)`, I have only tested this on x86 as I don't have an ARM Linux machine.
- Niri [supports X11 windows](https://github.com/YaLTeR/niri/wiki/Xwayland) via xwayland-satellite, but I have not tested this with any X11 windows in Niri.