### PR TITLE
fix some clippy warnings

### DIFF
--- a/src/client/wlroots_client.rs
+++ b/src/client/wlroots_client.rs
@@ -63,7 +63,7 @@ impl Client for WlRootsClient {
     fn current_window(&mut self) -> Option<String> {
         let queue = self.queue.as_mut()?;
 
-        if let Err(_) = queue.roundtrip(&mut self.state) {
+        if queue.roundtrip(&mut self.state).is_err() {
             // try to reconnect
             if let Err(err) = self.connect() {
                 log::error!("{err}");
@@ -80,7 +80,7 @@ impl Client for WlRootsClient {
     fn current_application(&mut self) -> Option<String> {
         let queue = self.queue.as_mut()?;
 
-        if let Err(_) = queue.roundtrip(&mut self.state) {
+        if queue.roundtrip(&mut self.state).is_err() {
             // try to reconnect
             if let Err(err) = self.connect() {
                 log::error!("{err}");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,7 +19,12 @@ use keymap::Keymap;
 use modmap::Modmap;
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use serde::{de::IgnoredAny, Deserialize, Deserializer};
-use std::{collections::HashMap, error, fs, path::PathBuf, time::SystemTime};
+use std::{
+    collections::HashMap,
+    error, fs,
+    path::{Path, PathBuf},
+    time::SystemTime,
+};
 
 use self::{
     key::parse_key,
@@ -61,7 +66,7 @@ enum ConfigFiletype {
     Toml,
 }
 
-fn get_file_ext(filename: &PathBuf) -> ConfigFiletype {
+fn get_file_ext(filename: &Path) -> ConfigFiletype {
     match filename.extension() {
         Some(f) => {
             if f.to_str().unwrap_or("").to_lowercase() == "toml" {
@@ -74,7 +79,7 @@ fn get_file_ext(filename: &PathBuf) -> ConfigFiletype {
     }
 }
 
-pub fn load_configs(filenames: &Vec<PathBuf>) -> Result<Config, Box<dyn error::Error>> {
+pub fn load_configs(filenames: &[PathBuf]) -> Result<Config, Box<dyn error::Error>> {
     // Assumes filenames is non-empty
     let config_contents = fs::read_to_string(&filenames[0])?;
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -155,8 +155,7 @@ pub struct InputDeviceInfo<'a> {
 }
 
 impl<'a> InputDeviceInfo<'a> {
-    pub fn matches(&self, filter: &String) -> bool {
-        let filter = filter.as_str();
+    pub fn matches(&self, filter: &str) -> bool {
         // Check exact matches for explicit selection
         if self.path.as_os_str() == filter || self.name == filter {
             return true;
@@ -290,7 +289,7 @@ impl InputDevice {
         }
     }
 
-    pub fn fetch_events(&mut self) -> io::Result<FetchEventsSynced> {
+    pub fn fetch_events(&mut self) -> io::Result<FetchEventsSynced<'_>> {
         self.device.fetch_events()
     }
 
@@ -310,7 +309,7 @@ impl InputDevice {
         self.device.input_id().vendor()
     }
 
-    pub fn to_info(&self) -> InputDeviceInfo {
+    pub fn to_info(&self) -> InputDeviceInfo<'_> {
         InputDeviceInfo {
             name: self.device_name(),
             product: self.product(),

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -253,8 +253,8 @@ impl EventHandler {
     fn timeout_override(&mut self) -> Result<(), Box<dyn Error>> {
         if let Some(keys) = &self.override_timeout_key.take() {
             for key in keys {
-                self.send_key(&key, PRESS);
-                self.send_key(&key, RELEASE);
+                self.send_key(key, PRESS);
+                self.send_key(key, RELEASE);
             }
         }
         self.remove_override()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -123,10 +123,10 @@ fn verify_disguised_relative_events() {
     use crate::event_handler::DISGUISED_EVENT_OFFSETTER;
     // Verifies that the event offsetter used to "disguise" relative events into key event
     // is a bigger number than the biggest one a scancode had at the time of writing this (26 december 2022)
-    assert!(0x2e7 < DISGUISED_EVENT_OFFSETTER);
+    const _: () = assert!(0x2e7 < DISGUISED_EVENT_OFFSETTER);
     // and that it's not big enough that one of the "disguised" events's scancode would overflow.
     // (the largest of those events is equal to DISGUISED_EVENT_OFFSETTER + 26)
-    assert!(DISGUISED_EVENT_OFFSETTER <= u16::MAX - 26)
+    const _: () = assert!(DISGUISED_EVENT_OFFSETTER <= u16::MAX - 26);
 }
 
 #[test]


### PR DESCRIPTION
I noticed some clippy warnings when packaging this project. I did see commit [`2e898ce`](https://github.com/xremap/xremap/commit/2e898cea84f229e434009e8e4b347b3a16e2b6c4) where you disabled clippy in CI because it warned on a cosmetic change, but some of the clippy warnings this time are actual improvements:

- writing `&PathBuf` instead of `&Path` involves a new object where a slice will do
- writing `&Vec` instead of `&[_]` involves a new object where a slice will do ([my bad](https://github.com/xremap/xremap/pull/269) 😓😓)
- writing `&String` instead of `&str` involves a new object where a slice will do
  - this also removes the need to call `filter.as_str()` on the line below
- the `&key` in `send_key` creates a reference that is immediately dereferenced by the compiler

Some changes are still cosmetic though. I can remove them from this PR if you don't like them:
- clippy thinks hiding a lifetime that's elided elsewhere is confusing, so it suggests adding the lifetime annotation on `FetchEventsSynced` and `InputDeviceInfo` when they are returned
- clippy warns about assertions on constants because they will be optimized out by the compiler. Adding a `const _: () = ` in front makes it more explicit and clear for readers that it is a compile-time assertion
- consider using `is_err()` when the pattern matching `let Err(_) =` is redundant