### PR TITLE
Add support for mapping one key to multiple in modmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,13 +243,15 @@ modmap:
     remap: # Required
       # Replace a key with another
       KEY_XXX1: KEY_YYY # Required
+      # Replace a key with multiple keys (pressed and released simultaneously)
+      KEY_XXX2: [KEY_YYY, KEY_ZZZ]
       # Dispatch different keys depending on whether you hold it or press it alone
-      KEY_XXX2:
+      KEY_XXX3:
         held: KEY_YYY # Required, also accepts arrays
         alone: KEY_ZZZ # Required, also accepts arrays
         alone_timeout_millis: 1000 # Optional
       # Hook `keymap` action on key press/release events.
-      KEY_XXX3:
+      KEY_XXX4:
         skip_key_event: true # Optional, skip original key event, defaults to false
         press: [{ press: KEY_YYY }, { launch: ["xdotool", "mousemove", "0", "7200"] }] # Optional
         repeat: { repeat: KEY_YYY } # Optional

--- a/src/config/modmap_action.rs
+++ b/src/config/modmap_action.rs
@@ -13,8 +13,7 @@ use super::{
 #[derive(Clone, Debug, Deserialize)]
 #[serde(untagged)]
 pub enum ModmapAction {
-    #[serde(deserialize_with = "deserialize_key")]
-    Key(Key),
+    Keys(Keys),
     MultiPurposeKey(MultiPurposeKey),
     PressReleaseKey(PressReleaseKey),
 }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -310,7 +310,11 @@ impl EventHandler {
         value: i32,
     ) -> Result<Vec<(Key, i32)>, Box<dyn Error>> {
         let keys = match key_action {
-            ModmapAction::Key(modmap_key) => vec![(modmap_key, value)],
+            ModmapAction::Keys(modmap_keys) => modmap_keys
+                .into_vec()
+                .into_iter()
+                .map(|modmap_key| (modmap_key, value))
+                .collect(),
             ModmapAction::MultiPurposeKey(MultiPurposeKey {
                 held,
                 alone,


### PR DESCRIPTION
I've implemented a new feature allowing a single key to be mapped to multiple keys in `modmap`. This feature is particularly useful for video games that don't allow one key to be bound to multiple in-game actions.