### PR TITLE
Add tests

### DIFF
--- a/src/config/application.rs
+++ b/src/config/application.rs
@@ -125,6 +125,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_exact_match() {
+        let matcher = ApplicationMatcher::from_str("class.name").unwrap();
+        assert!(matcher.matches("class.name"));
+        assert!(!matcher.matches("class"));
+        assert!(!matcher.matches("name"));
+    }
+
+    #[test]
+    fn test_name_match() {
+        let matcher = ApplicationMatcher::from_str("name").unwrap();
+        assert!(matcher.matches("class.name"));
+        assert!(matcher.matches("name"));
+        assert!(!matcher.matches("name.foo"));
+        assert!(!matcher.matches("name-and-more"));
+    }
+
+    #[test]
     fn test_literal_application_name_matcher() {
         let matcher = ApplicationMatcher::from_str(r"Minecraft").unwrap();
         assert!(matcher.matches("Minecraft"), "Failed to match exact Minecraft");

--- a/src/config/key.rs
+++ b/src/config/key.rs
@@ -131,3 +131,21 @@ pub fn parse_key(input: &str) -> Result<Key, Box<dyn Error>> {
 
     Err(format!("unknown key '{input}'").into())
 }
+
+#[test]
+fn test_parse_key() {
+    // Can omit the 'KEY_' prefex
+    assert_eq!(parse_key("Enter").unwrap(), Key::KEY_ENTER);
+
+    // Can use lower case
+    assert_eq!(parse_key("key_enter").unwrap(), Key::KEY_ENTER);
+
+    // Can use uppercase keys
+    assert_eq!(parse_key("KEY_ENTER").unwrap(), Key::KEY_ENTER);
+
+    // S is KEY_S, not shift.
+    assert_eq!(parse_key("S").unwrap(), Key::KEY_S);
+
+    // Modifier without sidedness can't be a key.
+    assert_eq!(parse_key("Shift").unwrap_err().to_string(), "unknown key 'Shift'");
+}

--- a/src/config/key_press.rs
+++ b/src/config/key_press.rs
@@ -70,3 +70,34 @@ fn parse_modifier(modifier: &str) -> Result<Modifier, Box<dyn Error>> {
         key => parse_key(key).map(Modifier::Key),
     }
 }
+
+#[test]
+fn test_parse_key_press() {
+    // Can have modifiers with unspecified sidedness
+    assert_eq!(
+        parse_key_press("Shift-2").unwrap(),
+        KeyPress {
+            key: Key::KEY_2,
+            modifiers: vec![Modifier::Shift]
+        }
+    );
+
+    // Can use custom key names. Defined in `parse_key`.
+    assert_eq!(
+        parse_key_press("Shift_L-2").unwrap(),
+        KeyPress {
+            key: Key::KEY_2,
+            modifiers: vec![Modifier::Key(Key::KEY_LEFTSHIFT)]
+        }
+    );
+
+    // All keys are accepted as modifiers, because it's not possible to know
+    // if the key is listed in virtual_modifers at this point.
+    assert_eq!(
+        parse_key_press("Enter-2").unwrap(),
+        KeyPress {
+            key: Key::KEY_2,
+            modifiers: vec![Modifier::Key(Key::KEY_ENTER)]
+        }
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,10 @@ mod event;
 mod event_handler;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_extra_modifiers;
+#[cfg(test)]
+mod tests_virtual_modifier;
 
 #[derive(Parser, Debug)]
 #[command(version)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -32,7 +32,7 @@ impl Client for StaticClient {
     }
 }
 
-fn get_input_device_info<'a>() -> InputDeviceInfo<'a> {
+pub fn get_input_device_info<'a>() -> InputDeviceInfo<'a> {
     InputDeviceInfo {
         name: "Some Device",
         path: Path::new("/dev/input/event0"),
@@ -776,11 +776,11 @@ fn test_any_key() {
     );
 }
 
-fn assert_actions(config_yaml: &str, events: Vec<Event>, actions: Vec<Action>) {
+pub fn assert_actions(config_yaml: &str, events: Vec<Event>, actions: Vec<Action>) {
     assert_actions_with_current_application(config_yaml, None, events, actions);
 }
 
-fn assert_actions_with_current_application(
+pub fn assert_actions_with_current_application(
     config_yaml: &str,
     current_application: Option<String>,
     events: Vec<Event>,

--- a/src/tests_extra_modifiers.rs
+++ b/src/tests_extra_modifiers.rs
@@ -1,0 +1,115 @@
+use crate::action::Action;
+use crate::event::Event;
+use crate::event::{KeyEvent, KeyValue};
+use crate::tests::{assert_actions, get_input_device_info};
+use evdev::KeyCode as Key;
+use indoc::indoc;
+use std::time::Duration;
+
+/// Tests the logic of extra_modifiers property in event_dispatcher
+/// This property ensures that extra modifiers that are pressed will
+/// be released when the mapping is emitted.
+
+#[test]
+fn test_on_left_side() {
+    assert_actions(
+        indoc! {"
+        keymap:
+            - remap:
+                CONTROL-A: B
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_on_right_side() {
+    assert_actions(
+        indoc! {"
+        keymap:
+            - remap:
+                A: CONTROL-B
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_modifier_not_released_in_inexact_match() {
+    assert_actions(
+        indoc! {"
+        keymap:
+            - remap:
+                A: B
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_virtual_modifier_is_not_considered_extra() {
+    assert_actions(
+        indoc! {"
+        virtual_modifiers:
+            - CAPSLOCK
+        keymap:
+            - remap:
+                CAPSLOCK-A: B
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+    )
+}

--- a/src/tests_virtual_modifier.rs
+++ b/src/tests_virtual_modifier.rs
@@ -1,0 +1,120 @@
+use crate::action::Action;
+use crate::event::Event;
+use crate::event::{KeyEvent, KeyValue};
+use crate::tests::{assert_actions, get_input_device_info};
+use evdev::KeyCode as Key;
+use indoc::indoc;
+use std::time::Duration;
+
+#[test]
+fn test_virtual_modifier_is_never_emitted() {
+    assert_actions(
+        indoc! {"
+        virtual_modifiers:
+            - CAPSLOCK
+
+        keymap:
+            - remap:
+                CAPSLOCK-A: B
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_virtual_modifier_in_inexact_match() {
+    assert_actions(
+        indoc! {"
+        virtual_modifiers:
+            - CAPSLOCK
+        keymap:
+            - remap:
+                CONTROL-A: B
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_ordinary_modifier_as_virtual() {
+    assert_actions(
+        indoc! {"
+        virtual_modifiers:
+            - WIN_L
+
+        keymap:
+            - remap:
+                WIN_L-A: B
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTMETA, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTMETA, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTMETA, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            // Bug: this must not happen, because WIN_L is not released again.
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTMETA, KeyValue::Press)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_modifier_not_declared() {
+    // Wouldn't it be better to give a warning here, telling the mapping has no effect? 
+    assert_actions(
+        indoc! {"
+        keymap:
+            - remap:
+                ENTER-A: B
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_ENTER, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_ENTER, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_ENTER, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_ENTER, KeyValue::Release)),
+        ],
+    )
+}


### PR DESCRIPTION
I have made some tests to increase code coverage.

Things to consider for future PRs

- `test_ordinary_modifier_as_virtual` Here a normal modifier is used as virtual. It fails by making keys stick. I could make a PR after this one, that gives an error instead so the users don't shoot themselves in the foot.
- `test_modifier_not_declared` If the user forgets to declare a modifier as virtual, it simply does nothing. I think it would be better to give an error. Or at least a warning to the user.