### PR TITLE
Allow any action in modmap's alone parameter

### DIFF
--- a/src/config/modmap_action.rs
+++ b/src/config/modmap_action.rs
@@ -22,7 +22,7 @@ pub enum ModmapAction {
 #[derive(Clone, Debug, Deserialize)]
 pub struct MultiPurposeKey {
     pub held: Keys,
-    pub alone: Keys,
+    pub alone: Actions,
     #[serde_as(as = "DurationMilliSeconds")]
     #[serde(default = "default_alone_timeout", rename = "alone_timeout_millis")]
     pub alone_timeout: Duration,

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -3,7 +3,7 @@ use crate::client::WMClient;
 use crate::config::application::OnlyOrNot;
 use crate::config::key_press::{KeyPress, Modifier};
 use crate::config::keymap::{build_override_table, OverrideEntry};
-use crate::config::keymap_action::KeymapAction;
+use crate::config::keymap_action::{Actions, KeymapAction};
 use crate::config::modmap_action::{Keys, ModmapAction, MultiPurposeKey, PressReleaseKey};
 use crate::config::remap::Remap;
 use crate::device::InputDeviceInfo;
@@ -120,7 +120,7 @@ impl EventHandler {
         self.application_cache = None; // expire cache
         self.title_cache = None; // expire cache
         let key = Key::new(event.code());
-        
+
         if key.code() < DISGUISED_EVENT_OFFSETTER {
             debug!("=> {}: {:?}", event.value(), &key);
         }
@@ -348,7 +348,19 @@ impl EventHandler {
                     }
                     RELEASE => {
                         if let Some(state) = self.multi_purpose_keys.remove(&key) {
-                            return Ok(state.release());
+                            self.dispatch_actions(
+                                &state
+                                    .release()
+                                    .into_iter()
+                                    .map(|action| TaggedAction {
+                                        action,
+                                        exact_match: false,
+                                    })
+                                    .collect(),
+                                &key,
+                            )?;
+                            // Releasing any held keys will be handled by the dispatched actions
+                            return Ok(vec![]);
                         }
                     }
                     _ => panic!("unexpected key event value: {value}"),
@@ -826,7 +838,7 @@ const REPEAT: i32 = 2;
 #[derive(Debug)]
 struct MultiPurposeKeyState {
     held: Keys,
-    alone: Keys,
+    alone: Actions,
     // Some if the first press is still delayed, None if already considered held.
     alone_timeout_at: Option<Instant>,
     held_down: bool,
@@ -854,17 +866,20 @@ impl MultiPurposeKeyState {
         }
     }
 
-    fn release(&self) -> Vec<(Key, i32)> {
+    fn release(self) -> Vec<KeymapAction> {
         match self.alone_timeout_at {
-            Some(alone_timeout_at) if Instant::now() < alone_timeout_at => self.press_and_release(&self.alone),
+            Some(alone_timeout_at) if Instant::now() < alone_timeout_at => self.alone.into_vec(),
             Some(_) => self.press_and_release(&self.held),
             None => match self.held_down {
                 true => {
                     let mut release_keys = self.held.clone().into_vec();
                     release_keys.sort_by(modifiers_last);
-                    release_keys.into_iter().map(|key| (key, RELEASE)).collect()
+                    release_keys
+                        .into_iter()
+                        .map(|key| KeymapAction::KeyRelease(key))
+                        .collect()
                 }
-                false => self.press_and_release(&self.alone),
+                false => self.alone.into_vec(),
             },
         }
     }
@@ -895,16 +910,15 @@ impl MultiPurposeKeyState {
         }
     }
 
-    fn press_and_release(&self, keys_to_use: &Keys) -> Vec<(Key, i32)> {
+    fn press_and_release(&self, keys_to_use: &Keys) -> Vec<KeymapAction> {
         let mut release_keys = keys_to_use.clone().into_vec();
         release_keys.sort_by(modifiers_last);
-        let release_events: Vec<(Key, i32)> = release_keys.into_iter().map(|key| (key, RELEASE)).collect();
+        let release_events = release_keys.into_iter().map(|key| KeymapAction::KeyRelease(key));
 
         let mut press_keys = keys_to_use.clone().into_vec();
         press_keys.sort_by(modifiers_first);
-        let mut events: Vec<(Key, i32)> = press_keys.into_iter().map(|key| (key, PRESS)).collect();
-        events.extend(release_events);
-        events
+        let events = press_keys.into_iter().map(|key| KeymapAction::KeyPress(key));
+        events.chain(release_events).collect()
     }
 }
 


### PR DESCRIPTION
I wanted to configure the meta key to open an application launcher if pressed on its own, but act normally if used as part of another keybinding. I tried to use the held/alone options for that, but the launch action isn't supported there.

This PR extends the alone option to match how the press option works. That means any KeymapAction can be used instead of only the ModmapActions.

I think this is technically a breaking change because existing configs will have a slightly different keypress order when mapping one key to many in the alone option. For example, `alone: [a, b]` used to trigger keydown for a and b, then keyup for those two. Now it'll press and release a, then press and release b. The original behavior can be emulated with something like the following (assuming there aren't subtleties I'm missing):
`alone: [{press: a}, {press: b}, {release: b}, {release: a}]`. I'm not sure if this is something people are relying on or not though.