### PR TITLE
Add tests of modmap

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -17,8 +17,8 @@ use std::os::linux::fs::MetadataExt;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::prelude::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::{io, process};
 use std::time::Duration;
+use std::{io, process};
 #[cfg(feature = "udev")]
 use udev::DeviceType;
 

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -844,6 +844,7 @@ struct MultiPurposeKeyState {
     alone: Actions,
     // Some if the first press is still delayed, None if already considered held.
     alone_timeout_at: Option<Instant>,
+    // Whether the multipurpose key is considered to be held down, and key presses has been emitted.
     held_down: bool,
 }
 
@@ -884,6 +885,8 @@ impl MultiPurposeKeyState {
         }
     }
 
+    // Other keys where pressed, so the multipurpose key
+    // should emit presses of its held-value.
     fn force_held(&mut self) -> Vec<(Key, i32)> {
         let press = match self.alone_timeout_at {
             Some(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,10 @@ mod tests;
 #[cfg(test)]
 mod tests_extra_modifiers;
 #[cfg(test)]
+mod tests_modmap_keys;
+#[cfg(test)]
+mod tests_modmap_mul_purpose;
+#[cfg(test)]
 mod tests_virtual_modifier;
 
 #[derive(Parser, Debug)]

--- a/src/tests_modmap_keys.rs
+++ b/src/tests_modmap_keys.rs
@@ -1,0 +1,159 @@
+use crate::action::Action;
+use crate::event::Event;
+use crate::event::{KeyEvent, KeyValue};
+use crate::tests::{assert_actions, get_input_device_info};
+use evdev::KeyCode as Key;
+use indoc::indoc;
+use std::time::Duration;
+
+#[test]
+fn test_modmap_one_key() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK: SHIFT_L
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_modmap_remap_two_concurrent_keys() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK: SHIFT_L
+              CTRL_L: ALT_L
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_modmap_only_emits_press_on_press() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK: SHIFT_L
+        "},
+        vec![Event::KeyEvent(
+            get_input_device_info(),
+            KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press),
+        )],
+        vec![Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press))],
+    );
+}
+
+#[test]
+fn test_modmap_can_emit_several_keys() {
+    // Note that modifiers are not sorted first/last as the multipurpose keys are.
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK: [SHIFT_L, V]
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_V, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_V, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_modmap_followed_by_same_emit_key() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK: SHIFT_L
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_modmap_preceded_by_same_emit_key() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK: SHIFT_L
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_modmap_output_is_used_in_keymap() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK: X
+        keymap:
+          - remap:
+              X: KEY_1
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+        ],
+    );
+}

--- a/src/tests_modmap_mul_purpose.rs
+++ b/src/tests_modmap_mul_purpose.rs
@@ -1,0 +1,357 @@
+use crate::action::Action;
+use crate::event::Event;
+use crate::event::{KeyEvent, KeyValue};
+use crate::tests::{assert_actions, get_input_device_info};
+use evdev::KeyCode as Key;
+use indoc::indoc;
+use std::time::Duration;
+
+#[test]
+fn test_multipurpose_emits_alone() {
+    let config = indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK:
+                held: SHIFT_L
+                alone: CAPSLOCK
+        "};
+
+    // Held key is emitted if another key is pressed before release
+    assert_actions(
+        config,
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+        ],
+    );
+
+    // Alone key is emitted if no another key is pressed before release
+    assert_actions(
+        config,
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_multipurpose_press_all_keys_then_release_all_keys() {
+    let config = indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK:
+                held: [X, Y]
+                alone: [A, B]
+        "};
+
+    // Held key will emit all key presses of the held-property before the triggering key is emitted.
+    assert_actions(
+        config,
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Release)),
+        ],
+    );
+
+    // Held key will emit all key presses of the held-property before the two triggering keys are emitted.
+    assert_actions(
+        config,
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_2, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_2, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Release)),
+        ],
+    );
+
+    // Alone key will emit all key presses before any release.
+    assert_actions(
+        config,
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+        ],
+    )
+}
+
+#[test]
+fn test_key_release_will_not_trigger_held() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK:
+                held: X
+                alone: Y
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_the_multipurpose_output_is_used_in_keymap() {
+    let config = indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK:
+                held: X
+                alone: Y
+                free_hold: true
+        keymap:
+          - remap:
+              X: KEY_1
+              Y: KEY_2
+        "};
+
+    // If key is held and a match in keymap is hit, then a keypress is emitted followed by the interrupting key.
+    // It has to be that way because keymap emits press/release already when the key is pressed.
+    assert_actions(
+        config,
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_1, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+        ],
+    );
+
+    // If key is alone and a match in keymap is hit then the keymap is used.
+    assert_actions(
+        config,
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Release)),
+        ],
+    );
+
+    // If key is alone while a non-modifier was already pressed.
+    assert_actions(
+        config,
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+        ],
+    );
+
+    // Alone while a modifier was already pressed
+    assert_actions(
+        config,
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_2, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_alone_is_not_optional() {
+    // The configuration is just ignored. A warning would be better.
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK:
+                held: X
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_held_is_not_optional() {
+    // The configuration is just ignored. A warning would be better.
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK:
+                alone: X
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_output_key_used_as_trigger() {
+    // A press is filtered from the output. Is there a reason for this. In which use case is it needed?
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK:
+                held: X
+                alone: Y
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_modifiers_are_sorted_first_and_last_held() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK:
+                held: [X, Control_L, Y]
+                alone: A
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_modifiers_are_sorted_first_and_last_alone() {
+    assert_actions(
+        indoc! {"
+        modmap:
+          - remap:
+              CAPSLOCK:
+                held: A
+                alone: [X, Control_L, Y]
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_CAPSLOCK, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_X, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_Y, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Release)),
+        ],
+    );
+}

--- a/src/tests_virtual_modifier.rs
+++ b/src/tests_virtual_modifier.rs
@@ -97,7 +97,7 @@ fn test_ordinary_modifier_as_virtual() {
 
 #[test]
 fn test_modifier_not_declared() {
-    // Wouldn't it be better to give a warning here, telling the mapping has no effect? 
+    // Wouldn't it be better to give a warning here, telling the mapping has no effect?
     assert_actions(
         indoc! {"
         keymap:
@@ -115,6 +115,36 @@ fn test_modifier_not_declared() {
             Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_ENTER, KeyValue::Release)),
+        ],
+    )
+}
+
+
+#[test]
+fn test_modmap_output_is_used_in_virtual_modifiers() {
+    assert_actions(
+        indoc! {"
+        modmap:
+            - remap:
+                Shift_L: Capslock
+        virtual_modifiers:
+            - Capslock
+        keymap:
+            - remap:
+                Capslock-A: B
+        "},
+        vec![
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Event::KeyEvent(get_input_device_info(), KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
         ],
     )
 }


### PR DESCRIPTION
I have created tests of modmap, which has seen regressions in 0.13.0. Documented here https://github.com/xremap/xremap/discussions/748 and here https://github.com/xremap/xremap/discussions/750

Some of the tests confirm the regresssions, and the rest is to created greater coverage of the modmap feature.

The tests in this PR does not pass on 0.13.0, but pass on 0.10.18 and backwards. So a revert would be needed before merging this PR.