### PR TITLE
Secure / Isolated KDE Wayland setup

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -8,6 +8,7 @@ You can choose between the following ways to run xremap. They are ordered by the
 - [Running without sudo](running_without_sudo.md)
 - [Running as a user service](running_as_user_service.md)
 - [Running as a system service](running_as_system_service.md)
+- [Running on KDE Wayland as an isolated service](kde-wayland/README.md)
 
 ### Troubleshooting
 

--- a/doc/kde-wayland/README.md
+++ b/doc/kde-wayland/README.md
@@ -1,0 +1,870 @@
+# Xremap Setup Guide for KDE Plasma Wayland
+
+This guide explains how to securely run xremap on KDE Plasma Wayland using a dedicated system user and socket-based helper for application-specific key remapping.
+
+## Table of Contents
+
+1. [Overview and Security Model](#overview-and-security-model)
+2. [Architecture](#architecture)
+3. [Prerequisites](#prerequisites)
+4. [Installation](#installation)
+5. [Configuration](#configuration)
+6. [Verification](#verification)
+7. [Troubleshooting](#troubleshooting)
+8. [Cleanup and Removal](#cleanup-and-removal)
+
+---
+
+## Overview and Security Model
+
+### The Security Problem
+
+When xremap needs to remap keyboard input, it requires access to input devices (`/dev/input/event*`). On Linux, this access is controlled by the `input` group. The security concern is:
+
+- **Dangerous approach**: Add your regular user (e.g., `yourusername`) to the `input` group
+  - **Problem**: *Any application* running as your user can now read keyboard input
+  - **Consequence**: Malicious software, compromised apps, or even buggy programs could log your keystrokes (passwords, chat messages, etc.)
+
+### The Secure Solution
+
+Instead, xremap should run as a **dedicated system user**:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│   Your User (`yourusername`)                                │
+│   - Runs your applications (browser, terminal, IDE, etc.)   │
+│   - NOT in the `input` group                                │
+│   - Cannot access raw keyboard input                        │
+│   - Even if compromised, cannot read keystrokes             │
+└─────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────┐
+│   `xremap` System User                                     │
+│   - Runs ONLY the xremap process                           │
+│   - IS in the `input` group                                │
+│   - Has access to input devices (for remapping)            │
+│   - Minimal privileges, no login shell                     │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Benefits
+
+- **Principle of least privilege**: Only xremap can read keyboard input
+- **Isolation**: If your user account is compromised, keystrokes remain protected
+- **Containment**: Compromised xremap process can only affect key remapping, not your user data
+- **Application-specific remapping**: Still works via socket-based helper
+
+### Cross-User Challenge
+
+KDE Plasma's window manager (KWin) runs as your regular user and communicates via D-Bus. For xremap to support application-specific remapping (e.g., different keybindings in Konsole vs Firefox), it needs window information from KWin.
+
+The solution: A **socket-based helper** that runs as your user, talks to KWin via D-Bus, and forwards window information to xremap via a Unix socket.
+
+---
+
+## Architecture
+
+### Component Overview
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│                    xremap (system user)                       │
+├───────────────────────────────────────────────────────────────┤
+│  - Reads input devices (/dev/input/eventX)                    │
+│  - Processes keystrokes locally (never shares keystroke data) │
+│  - Writes remapped output to uinput device                    │
+│  - Reads window info from socket (for app-specific remapping) │
+│  - Groups: xremap, input                                      │
+└───────────────────────────────────────────────────────────────┘
+                      ↓ Unix socket (JSON protocol)
+┌───────────────────────────────────────────────────────────────┐
+│           kde-socket-helper (runs as yourusername)            │
+├───────────────────────────────────────────────────────────────┤
+│  - Listens on /run/xremap/kde.sock                            │
+│  - Loads KWin script via D-Bus (same user)                    │
+│  - Receives window change events from KWin                    │
+│  - Writes JSON window info to socket for xremap               │
+│  - Groups: yourusername, wheel, docker                        │
+└───────────────────────────────────────────────────────────────┘
+                      ↓ D-Bus session bus (same user)
+┌───────────────────────────────────────────────────────────────┐
+│                     KWin Window Manager                       │
+│                     Runs within KDE session                   │
+├───────────────────────────────────────────────────────────────┤
+│  - Detects active window changes                              │
+│  - KWin script calls helper via D-Bus                         │
+│  - Script ID: xremap-helper                                   │
+└───────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+**Window/Application Information (for filtering):**
+```
+User switches window → KWin detects change → KWin script notifies helper via D-Bus
+→ Helper writes JSON to socket → xremap reads JSON → xremap updates key remapping
+```
+
+**Keystroke Remapping (isolated):**
+```
+Keyboard → Input device (/dev/input/eventX) → xremap → uinput device
+→ Kernel delivers to applications
+```
+
+**Critical Security Point:** Keystrokes never flow through the socket or D-Bus. Only window metadata (title, class, name) is shared.
+
+### Communication Protocol
+
+**Helper → xremap** (Unix socket): JSON object on each line
+```json
+{"caption": "Window Title", "class": "org.kde.konsole", "app_id": "konsole"}
+```
+
+**Why JSON?**
+- Handles special characters (quotes, pipes, commas) in window titles
+- No parsing ambiguity
+- Extensible for future features
+
+---
+
+## Prerequisites
+
+### System Requirements
+
+- Fedora Linux with KDE Plasma Wayland
+- Python 3 with D-Bus support
+- System administrator access (sudo)
+- Rust toolchain (for building xremap)
+
+### Packages to Install
+
+```bash
+# Required for KDE socket helper
+sudo dnf install -y python3-dbus python3-gobject
+
+# Required for building xremap
+sudo dnf install -y cargo rust
+
+# Required for uinput device access
+# Note: MODE="0660" ensures consistent group-based permissions without ACL interference
+echo 'KERNEL=="uinput", GROUP="input", MODE="0660"' | sudo tee /etc/udev/rules.d/input.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+### About tmpfiles.d
+
+The setup uses systemd's `tmpfiles.d` mechanism to create the `/run/xremap` directory at boot time. This directory is used for socket communication between the helper (running as your user) and xremap (running as the xremap user).
+
+The configuration file `xremap-tmpfiles.conf` contains:
+```
+# Create xremap socket directory
+# Owner: root, Group: root, Mode: 1777 (world-writable with sticky bit)
+# Sticky bit prevents users from deleting each other's files
+d /run/xremap 1777 root root -
+```
+
+This configuration ensures:
+- `/run/xremap` is created automatically at boot
+- Directory has permissions 1777 (world-writable with sticky bit)
+- Prevents permission issues between the two users
+- Sticky bit prevents users from deleting each other's files (similar to `/tmp`)
+
+This is a one-time setup step - no manual intervention is needed on login or reboot.
+
+---
+
+## Installation
+
+Follow these steps to set up xremap with the secure architecture on KDE Plasma Wayland.
+
+### Step 1: Create the xremap System User
+
+Create a dedicated system user with no home directory or login shell:
+
+```bash
+# Create system user
+sudo useradd -r -s /usr/sbin/nologin xremap
+
+# Add xremap to input group (required for keyboard access)
+sudo usermod -a -G input xremap
+
+# Verify creation
+id xremap
+```
+
+### Step 2: Build and Install xremap
+
+Build xremap with KDE support and install it system-wide:
+
+```bash
+# Navigate to xremap source directory
+cd /path/to/xremap
+
+# Build with KDE feature
+cargo build --release --features kde
+
+# Install binary
+sudo cp target/release/xremap /usr/bin/xremap
+sudo chmod +x /usr/bin/xremap
+
+# Verify installation
+/usr/bin/xremap --version
+```
+
+### Step 3: Install the KDE Socket Helper and tmpfiles.d Config
+
+Copy the Python helper script and tmpfiles.d configuration:
+
+```bash
+# Copy helper script
+sudo cp kde-socket-helper.py /usr/local/bin/kde-socket-helper
+
+# Make executable
+sudo chmod +x /usr/local/bin/kde-socket-helper
+
+# Verify script is accessible
+which kde-socket-helper
+
+# Copy tmpfiles.d config for socket directory
+sudo cp xremap-tmpfiles.conf /etc/tmpfiles.d/
+sudo systemd-tmpfiles --create /etc/tmpfiles.d/xremap-tmpfiles.conf
+```
+
+### Step 4: Configure systemd Services
+
+You need two systemd services:
+1. **xremap.service**: System service that runs xremap as the xremap user
+2. **kde-socket-helper.service**: User service that runs the helper as your regular user
+
+#### Install xremap System Service
+
+```bash
+# Copy system service file
+sudo cp xremap.service /etc/systemd/system/
+```
+
+The service file should look like:
+```ini
+[Unit]
+Description=Xremap (run as xremap user)
+After=default.target yourusername-user@yourusername.service kde-socket-helper.service systemd-udev-trigger.service systemd-udev-settle.service
+
+[Service]
+Type=simple
+User=xremap
+Group=input
+ExecStart=/usr/bin/xremap --redact --watch=config /etc/xremap/config.yml
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+Environment=RUST_LOG=warn
+Environment=KDE_SOCKET=/run/xremap/kde.sock
+SupplementaryGroups=input
+
+[Install]
+WantedBy=default.target
+```
+
+**Note:** Adjust `yourusername` in `After=` directive if your username is different.
+
+#### Install KDE Helper User Service
+
+```bash
+# Create user service directory if it doesn't exist
+mkdir -p ~/.config/systemd/user
+
+# Copy helper service file
+cp kde-socket-helper.service ~/.config/systemd/user/
+
+# Reload user systemd daemon
+systemctl --user daemon-reload
+
+# Enable helper to start on login
+systemctl --user enable kde-socket-helper.service
+```
+
+### Files to Install
+
+Here's a quick reference of all files that need to be installed and where they go:
+
+| Source File | Destination | Description |
+|-------------|--------------|-------------|
+| `target/release/xremap` | `/usr/bin/xremap` | xremap binary |
+| `kde-socket-helper.py` | `/usr/local/bin/kde-socket-helper` | KDE socket helper script (includes retry logic for KWin) |
+| `xremap.service` | `/etc/systemd/system/xremap.service` | xremap system service |
+| `kde-socket-helper.service` | `~/.config/systemd/user/kde-socket-helper.service` | KDE helper user service |
+| `xremap-tmpfiles.conf` | `/etc/tmpfiles.d/xremap-tmpfiles.conf` | tmpfiles.d config for socket directory |
+| `/etc/xremap/config.yml` | `/etc/xremap/config.yml` | xremap configuration file (create this) |
+
+### Step 5: Create xremap Configuration Directory and Config
+
+```bash
+# Create configuration directory
+sudo mkdir -p /etc/xremap
+
+# Set permissions
+sudo chown xremap:xremap /etc/xremap
+sudo chmod 755 /etc/xremap
+```
+
+Create or copy your xremap configuration:
+
+```bash
+# Example configuration with application-specific remapping
+sudo tee /etc/xremap/config.yml > /dev/null << 'EOF'
+# Global key remapping (works in all apps)
+modmap:
+  - name: Global remaps
+    remap:
+      CapsLock: Esc
+
+# Application-specific remapping
+keymap:
+  - name: Konsole-specific bindings
+    application:
+      only: konsole
+    remap:
+      Super-v: C-S-v  # Paste in Konsole only
+
+  - name: VSCodium-specific bindings
+    application:
+      only: codium
+    remap:
+      Super-Shift-e: C-e  # End of line in VSCodium only
+
+  - name: Copy shortcut (all apps except Konsole)
+    application:
+      not: konsole
+    remap:
+      Super-c: C-c  # Copy in all apps except Konsole
+EOF
+
+# Set ownership
+sudo chown xremap:xremap /etc/xremap/config.yml
+sudo chmod 644 /etc/xremap/config.yml
+```
+
+### Step 6: Start the Services
+
+Start the services in the correct order:
+
+```bash
+# Start KDE helper first (must be running before xremap)
+systemctl --user start kde-socket-helper.service
+
+# Verify helper is running
+systemctl --user status kde-socket-helper.service
+
+# Start xremap
+sudo systemctl start xremap.service
+
+# Enable xremap to start on boot
+sudo systemctl enable xremap.service
+
+# Verify xremap is running
+sudo systemctl status xremap.service
+```
+
+### Step 7: Verify Installation
+
+Check that everything is working correctly:
+
+```bash
+# Check if socket exists
+ls -la /run/xremap/kde.sock
+# Should show: srw-rw-rw-. 1 yourusername yourusername ... kde.sock
+
+# Check that xremap user can access socket
+sudo -u xremap ls -la /run/xremap/kde.sock
+# Should show the socket file
+
+# Check xremap logs for successful connection
+journalctl -u xremap -n 50 --no-pager
+# Switch between supported apps in your configuration first, then you:
+# Should see: application-client: KDE (supported: true)
+# Should see: active window: caption: '...', class: '...', name: '...'
+
+# Check helper logs
+journalctl --user -u kde-socket-helper -n 50 --no-pager
+# Should show: KWin script loaded successfully
+# Should show: Using existing directory /run/xremap or Socket created at /run/xremap
+```
+
+### Step 8: Test Application-Specific Remapping
+
+Open different applications and verify keybindings work as configured:
+
+```bash
+# Test in Konsole
+# Open Konsole and press Super-v (should paste with Ctrl-Shift-v)
+
+# Test in VSCodium
+# Open VSCodium and press Super-Shift-e (should go to end of line)
+
+# Test in other app (e.g., Firefox)
+# Press Super-c (should copy with Ctrl-c)
+```
+
+Monitor logs while testing:
+```bash
+sudo journalctl -u xremap -f --no-pager
+# Should see window change messages when switching apps
+```
+
+---
+
+## Configuration
+
+### Application-Specific Remapping
+
+xremap can apply different keybindings based on the active application. To find application class names:
+
+1. Check xremap logs when switching windows:
+   ```bash
+   sudo journalctl -u xremap -f --no-pager
+   ```
+2. Look for messages like: `active window: caption: '...', class: 'org.kde.konsole', name: '...'`
+3. Use the `class` field in your config
+
+Example configuration:
+```yaml
+keymap:
+  - name: Emacs bindings in specific apps
+    application:
+      only: [codium, emacs, vim]
+    remap:
+      C-b: left
+      C-f: right
+      C-p: up
+      C-n: down
+```
+
+### Window-Specific Remapping
+
+You can also match based on window title (caption):
+
+```yaml
+keymap:
+  - name: Special keys in password manager window
+    window:
+      only: /.*Bitwarden.*/
+    remap:
+      Super-l: C-l  # Lock field
+```
+
+### Mode-Based Remapping
+
+For modal interfaces like Vim or Emacs:
+
+```yaml
+modmap:
+  - name: Emacs-like Ctrl key as modifier
+    mode: emacs-mode
+    remap:
+      Ctrl_L:
+        held: Ctrl_L
+        alone: Esc
+        free_hold: true
+
+keymap:
+  - name: Enter Emacs mode
+    remap:
+      Super-e: { set_mode: emacs-mode }
+
+  - name: Exit Emacs mode
+    mode: emacs-mode
+    remap:
+      Esc: { set_mode: default }
+```
+
+### Redacting Window Titles
+
+For privacy, you can redact window titles in logs:
+
+```bash
+# Edit xremap.service to add --redact flag
+sudo systemctl edit xremap.service
+```
+
+Add to the `[Service]` section:
+```ini
+ExecStart=/usr/bin/xremap --watch=config --redact /etc/xremap/config.yml
+```
+
+Restart the service:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart xremap.service
+```
+
+Now logs will show: `active window: caption: '[REDACTED]', class: '...', name: '...'`
+
+---
+
+## Verification
+
+### Security Verification
+
+Verify that your regular user is **not** in the input group:
+
+```bash
+groups
+# Output should NOT include 'input'
+```
+
+Verify that xremap IS in the input group:
+
+```bash
+groups xremap
+# Output should include 'input'
+```
+
+Verify that your user cannot read keyboard input:
+
+```bash
+# Try to read from an input device
+cat /dev/input/event0
+# Should show: Permission denied
+```
+
+Verify that xremap can read keyboard input:
+
+```bash
+sudo -u xremap ls -la /dev/input/event*
+# Should show readable input devices
+```
+
+Verify that uinput device has correct permissions:
+
+```bash
+ls -la /dev/uinput
+# Should show: crw-rw----. 1 root input
+# If you see different permissions, re-run the udev rule setup from Prerequisites
+```
+
+### Functionality Verification
+
+**Test 1: Global key remapping works**
+```bash
+# Press CapsLock - should behave as Esc
+# Works in all applications
+```
+
+**Test 2: Application-specific remapping works**
+```bash
+# Open Konsole, press Super-v - should paste (Ctrl-Shift-v)
+# Open Firefox, press Super-v - should do nothing
+```
+
+**Test 3: Window information is received**
+```bash
+sudo journalctl -u xremap -n 20 --no-pager | grep "active window"
+# Should show window info for each window switch
+```
+
+**Test 4: KWin script is loaded**
+```bash
+qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.isScriptLoaded xremap-helper
+# Should return: true
+```
+
+### Service Status Verification
+
+```bash
+# Check xremap system service
+sudo systemctl status xremap.service
+# Should show: Active: active (running)
+
+# Check KDE helper user service
+systemctl --user status kde-socket-helper.service
+# Should show: Active: active (running)
+
+# Check socket exists
+ls -la /run/xremap/kde.sock
+# Should show: srw-rw-rw-. 1 yourusername yourusername
+```
+
+---
+
+## Troubleshooting
+
+### xremap shows "application-client: KDE (supported: false)"
+
+**Symptom:** Application-specific remapping doesn't work.
+
+**Possible causes:**
+
+1. **KDE helper not running**
+   ```bash
+   systemctl --user status kde-socket-helper.service
+   ```
+   If not running: `systemctl --user start kde-socket-helper.service`
+
+2. **Socket doesn't exist**
+   ```bash
+   ls -la /run/xremap/kde.sock
+   ```
+   If missing: Restart helper service
+
+3. **Socket permissions wrong**
+   ```bash
+   ls -la /run/xremap/kde.sock
+   ```
+   Should show: `srw-rw-rw-` (mode 666)
+
+4. **xremap can't access socket**
+   ```bash
+   sudo -u xremap ls -la /run/xremap/kde.sock
+   ```
+   If permission denied: Check `/run/xremap` directory exists and has correct permissions (1777)
+
+### "Could not connect to kwin-script" Error
+
+**Symptom:** xremap logs show connection error.
+
+**Solution:** This error is normal with socket-based architecture. xremap doesn't need direct D-Bus connection anymore. Verify:
+- KDE helper is running
+- Socket exists and is accessible
+- xremap shows `supported: true` eventually
+
+### Application filtering not working
+
+**Symptom:** Keybindings work the same in all applications.
+
+**Troubleshooting:**
+
+1. Check application class names in logs:
+   ```bash
+   sudo journalctl -u xremap -f --no-pager
+   # Switch windows and look for: active window: class: '...'
+   ```
+
+2. Verify config matches class name exactly:
+   - Konsole: `org.kde.konsole` or `konsole`
+   - VSCodium: `codium`
+   - Firefox: `firefox`
+   - Chrome: `google-chrome`
+
+3. Test with exact match:
+   ```yaml
+   keymap:
+     - name: Test
+       application:
+         only: konsole  # Use exact class name
+       remap:
+         Super-x: left
+   ```
+
+### xremap won't start
+
+**Symptom:** Service fails to start.
+
+**Check logs:**
+```bash
+sudo journalctl -u xremap -n 50 --no-pager
+```
+
+**Common issues:**
+
+1. **Config file error**: Syntax error in `/etc/xremap/config.yml`
+   - Validate YAML syntax
+   - Check for indentation errors
+
+2. **Missing input device access**:
+   ```bash
+   sudo -u xremap ls -la /dev/input/
+   ```
+   - Verify xremap is in input group
+   - Check udev rules are loaded
+
+3. **Permission denied on config**:
+   ```bash
+   ls -la /etc/xremap/config.yml
+   ```
+   - Should be owned by xremap:xremap
+   - Should be readable (644)
+
+4. **uinput permission denied**:
+   ```
+   Error: Failed to prepare an output device: Permission denied (os error 13)
+   ```
+   This error occurs when the udev rule uses `TAG+="uaccess"` instead of `MODE="0660"`. The uaccess tag sets up ACLs for the logged-in user that can interfere with group-based access.
+
+   **Fix**: Update the udev rule:
+   ```bash
+   echo 'KERNEL=="uinput", GROUP="input", MODE="0660"' | sudo tee /etc/udev/rules.d/input.rules
+   sudo udevadm control --reload-rules
+   sudo udevadm trigger
+   sudo systemctl restart xremap.service
+   ```
+
+   **Verify**: Check that uinput has correct permissions:
+   ```bash
+   ls -la /dev/uinput
+   # Should show: crw-rw----. 1 root input
+   ```
+
+### KDE helper won't start
+
+**Symptom:** User service fails to start.
+
+**Check logs:**
+```bash
+journalctl --user -u kde-socket-helper -n 50 --no-pager
+```
+
+**Common issues:**
+
+1. **Missing Python dependencies**:
+   ```bash
+   sudo dnf install python3-dbus python3-gobject
+   ```
+
+2. **DBus session not ready**:
+   - Ensure user is logged into KDE session
+   - Check `echo $DBUS_SESSION_BUS_ADDRESS`
+
+3. **KWin script fails to load at boot**:
+   - Symptom: Helper logs show `ERROR: qdbus loadScript failed` after reboot
+   - Cause: KWin window manager may not be ready when helper starts at boot
+   - Solution: The helper now includes automatic retry logic (up to 5 attempts, 2 second delay each). If you see this error:
+     - Wait a few seconds - the helper will retry automatically
+     - Check logs for subsequent success messages: `INFO: Loaded KWin script with ID:`
+     - If retries still fail, check helper logs and verify KWin is running
+   - Manual test: Try loading the script manually once KWin is running:
+     ```bash
+     qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript /path/to/kde-helper-script.js
+     ```
+
+### After reboot, services don't start automatically
+
+**Symptom:** Services need manual start after reboot.
+
+**Solutions:**
+
+1. **Verify services are enabled**:
+   ```bash
+   sudo systemctl is-enabled xremap.service
+   systemctl --user is-enabled kde-socket-helper.service
+   ```
+   Should both return `enabled`.
+
+2. **Check dependencies in service file**:
+   ```bash
+   sudo cat /etc/systemd/system/xremap.service | grep After=
+   ```
+   Ensure `After=` includes user service.
+
+3. **Check for startup failures**:
+   ```bash
+   sudo journalctl -b | grep xremap
+   journalctl -b --user | grep kde-socket-helper
+   ```
+
+### Socket directory doesn't exist after reboot
+
+**Symptom:** `/run/xremap/` missing after reboot.
+
+**Solution:** The tmpfiles.d config should create it automatically. If it's missing:
+```bash
+# Verify tmpfiles.d config exists
+ls /etc/tmpfiles.d/xremap-tmpfiles.conf
+
+# Manually create directory
+sudo systemd-tmpfiles --create /etc/tmpfiles.d/xremap-tmpfiles.conf
+
+# Restart helper service
+systemctl --user restart kde-socket-helper.service
+```
+
+If the problem persists, verify the tmpfiles.d configuration:
+```bash
+# Check tmpfiles.d config
+sudo cat /etc/tmpfiles.d/xremap-tmpfiles.conf
+# Should contain: d /run/xremap 1777 root root -
+```
+
+---
+
+## Cleanup and Removal
+
+To completely remove xremap setup:
+
+### Stop and Disable Services
+
+```bash
+# Stop xremap system service
+sudo systemctl stop xremap.service
+sudo systemctl disable xremap.service
+
+# Stop KDE helper user service
+systemctl --user stop kde-socket-helper.service
+systemctl --user disable kde-socket-helper.service
+```
+
+### Remove Service Files
+
+```bash
+sudo rm /etc/systemd/system/xremap.service
+rm ~/.config/systemd/user/kde-socket-helper.service
+
+# Reload systemd
+sudo systemctl daemon-reload
+systemctl --user daemon-reload
+```
+
+### Remove Executables
+
+```bash
+sudo rm /usr/bin/xremap
+sudo rm /usr/local/bin/kde-socket-helper
+```
+
+### Remove Configuration
+
+```bash
+sudo rm -rf /etc/xremap
+```
+
+### Remove Socket Directory
+
+```bash
+sudo rm -rf /run/xremap
+sudo rm /etc/tmpfiles.d/xremap-tmpfiles.conf
+```
+
+### Remove xremap User
+
+```bash
+sudo userdel xremap
+```
+
+### Verify Removal
+
+```bash
+# Check user doesn't exist
+id xremap
+# Should show: no such user
+
+# Check files removed
+ls /usr/bin/xremap
+# Should show: No such file or directory
+
+ls /etc/xremap
+# Should show: No such file or directory
+```
+
+---
+
+## Summary
+
+This setup provides a secure, isolated environment for xremap on KDE Plasma Wayland:
+
+- **Security**: Your regular user is not in the `input` group, preventing arbitrary applications from reading keystrokes
+- **Isolation**: xremap runs as a dedicated system user with minimal privileges
+- **Functionality**: Application-specific and window-specific remapping work via socket-based helper
+- **Maintainability**: Simple architecture using standard Unix sockets, systemd services, and tmpfiles.d for automatic directory creation
+- **Cross-user socket**: Uses `/run/xremap/` (mode 1777) for secure communication between helper and xremap users
+
+For questions or issues, refer to the troubleshooting section or check the project documentation.

--- a/doc/kde-wayland/README.md
+++ b/doc/kde-wayland/README.md
@@ -313,29 +313,17 @@ Create or copy your xremap configuration:
 ```bash
 # Example configuration with application-specific remapping
 sudo tee /etc/xremap/config.yml > /dev/null << 'EOF'
-# Global key remapping (works in all apps)
-modmap:
-  - name: Global remaps
-    remap:
-      CapsLock: Esc
-
 # Application-specific remapping
 keymap:
   - name: Konsole-specific bindings
     application:
-      only: konsole
+      only: org.kde.konsole
     remap:
-      Super-v: C-S-v  # Paste in Konsole only
-
-  - name: VSCodium-specific bindings
-    application:
-      only: codium
-    remap:
-      Super-Shift-e: C-e  # End of line in VSCodium only
+      Super-v: C-Shift-v  # Paste in Konsole only
 
   - name: Copy shortcut (all apps except Konsole)
     application:
-      not: konsole
+      not: org.kde.konsole
     remap:
       Super-c: C-c  # Copy in all apps except Konsole
 EOF
@@ -478,28 +466,6 @@ keymap:
       Esc: { set_mode: default }
 ```
 
-### Redacting Window Titles
-
-For privacy, you can redact window titles in logs:
-
-```bash
-# Edit xremap.service to add --redact flag
-sudo systemctl edit xremap.service
-```
-
-Add to the `[Service]` section:
-```ini
-ExecStart=/usr/bin/xremap --watch=config --redact /etc/xremap/config.yml
-```
-
-Restart the service:
-```bash
-sudo systemctl daemon-reload
-sudo systemctl restart xremap.service
-```
-
-Now logs will show: `active window: caption: '[REDACTED]', class: '...', name: '...'`
-
 ---
 
 ## Verification
@@ -641,7 +607,7 @@ ls -la /run/xremap/kde.sock
    ```
 
 2. Verify config matches class name exactly:
-   - Konsole: `org.kde.konsole` or `konsole`
+   - Konsole: `org.kde.konsole`
    - VSCodium: `codium`
    - Firefox: `firefox`
    - Chrome: `google-chrome`

--- a/doc/kde-wayland/kde-socket-helper.py
+++ b/doc/kde-wayland/kde-socket-helper.py
@@ -2,18 +2,21 @@
 """
 KDE socket helper for xremap.
 Provides window information via Unix socket to avoid D-Bus EXTERNAL authentication issues.
+Requires KDE Plasma 6.
 """
 
 import argparse
 import json
 import logging
 import os
+import re
 import signal
 import socket
 import sys
 import tempfile
+import time
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
 
 import dbus
 import dbus.mainloop.glib
@@ -28,137 +31,11 @@ logging.basicConfig(
 )
 log = logging.getLogger('xremap-kde')
 
+# KWin script for Plasma 6
+KWIN_SCRIPT_CODE = '''
+// Plasma 6 active window notifier for xremap
 
-class KdeSocketHelper:
-    def __init__(self, socket_path: str):
-        self.socket_path = Path(socket_path)
-        self.socket_dir = self.socket_path.parent
-        self.server_socket: Optional[socket.socket] = None
-        self.running = False
-        self.clients: list[socket.socket] = []
-        self.current_window: dict = {
-            'caption': '',
-            'class': '',
-            'app_id': ''
-        }
-        self.kwin_script_path = None
-        self.kwin_script_id = None
-
-    def setup(self):
-        """Create socket directory and socket"""
-        import pwd
-
-        # Use system-wide runtime directory for cross-user access
-        self.socket_dir = Path("/run/xremap")
-
-        # Only try to create /run/xremap if it doesn't exist
-        if not self.socket_dir.exists():
-            try:
-                self.socket_dir.mkdir(parents=True, exist_ok=True)
-                # Set permissions to allow xremap user to access
-                os.chmod(str(self.socket_dir), 0o755)
-                log.info(f"Created directory {self.socket_dir}")
-            except PermissionError:
-                # If we can't create /run/xremap (as user), fall back to user runtime
-                uid = os.getuid()
-                self.socket_dir = Path(f"/run/user/{uid}/xremap")
-                self.socket_dir.mkdir(parents=True, exist_ok=True)
-                os.chmod(str(self.socket_dir), 0o755)
-                log.warning(f"Could not create /run/xremap, using {self.socket_dir} instead")
-        else:
-            # Directory exists, verify we can write to it
-            if os.access(str(self.socket_dir), os.W_OK):
-                log.info(f"Using existing directory {self.socket_dir}")
-            else:
-                # Can't write to /run/xremap, fall back to user runtime
-                uid = os.getuid()
-                self.socket_dir = Path(f"/run/user/{uid}/xremap")
-                self.socket_dir.mkdir(parents=True, exist_ok=True)
-                os.chmod(str(self.socket_dir), 0o755)
-                log.warning(f"Cannot write to /run/xremap, using {self.socket_dir} instead")
-
-        self.socket_path = self.socket_dir / "kde.sock"
-
-        # Remove existing socket if present
-        if self.socket_path.exists():
-            self.socket_path.unlink()
-
-        # Create Unix socket
-        self.server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.server_socket.bind(str(self.socket_path))
-
-        # Set permissions to allow xremap user to connect
-        os.chmod(str(self.socket_path), 0o666)
-        log.info(f"Socket created at {self.socket_path} (mode 666 for universal access)")
-
-        # Listen for connections
-        self.server_socket.listen(5)
-        self.server_socket.setblocking(False)
-        log.info(f"Listening on {self.socket_path}")
-        # Print socket path for easy reference
-        print(f"SOCKET_PATH={self.socket_path}")
-
-        # Setup GLib watch for incoming connections
-        GLib.io_add_watch(
-            self.server_socket.fileno(),
-            GLib.IO_IN,
-            self.handle_connection
-        )
-
-    def handle_connection(self, fd, condition):
-        """Handle new connection"""
-        if condition & GLib.IO_IN:
-            try:
-                client_socket, _ = self.server_socket.accept()
-                client_socket.setblocking(False)
-                self.clients.append(client_socket)
-                log.info(f"Client connected (total: {len(self.clients)})")
-
-                # Send current window info immediately
-                self.broadcast_window_info()
-            except BlockingIOError:
-                pass
-        return True
-
-    def notify_active_window(self, caption: str, res_class: str, res_name: str):
-        """Called by KWin script via D-Bus"""
-        self.current_window = {
-            'caption': caption,
-            'class': res_class,
-            'app_id': res_name
-        }
-        self.broadcast_window_info()
-
-    def broadcast_window_info(self):
-        """Send window info to all connected clients"""
-        if not self.clients:
-            return
-
-        # Use JSON format for robustness (handles special characters, quotes, etc.)
-        data = json.dumps(self.current_window, ensure_ascii=False)
-        message = f"{data}\n"
-
-        # Send to all clients, removing any that fail
-        remaining_clients = []
-        for client in self.clients:
-            try:
-                client.sendall(message.encode('utf-8'))
-                remaining_clients.append(client)
-            except (BrokenPipeError, ConnectionResetError, OSError) as e:
-                log.debug(f"Removing disconnected client: {e}")
-                try:
-                    client.close()
-                except:
-                    pass
-
-        self.clients = remaining_clients
-
-    def load_kwin_script(self, max_retries=5, retry_delay=2):
-        """Load KWin script using qdbus, with retries for boot-time availability"""
-        import subprocess
-        import time
-
-        script_code = '''function notifyActiveWindow(client) {
+function notifyActiveWindow(client) {
     if (!client) {
         return;
     }
@@ -169,151 +46,326 @@ class KdeSocketHelper:
             "/com/k0kubun/XremapHelper",
             "com.k0kubun.XremapHelper",
             "NotifyActiveWindow",
-            "caption" in client ? client.caption : "",
-            "resourceClass" in client ? client.resourceClass : "",
-            "resourceName" in client ? client.resourceName : ""
+            client.caption || "",
+            client.resourceClass || "",
+            client.resourceName || ""
         );
     } catch (e) {
-        print("Error in notifyActiveWindow: " + e);
+        print("xremap-helper: Error in notifyActiveWindow: " + e);
     }
 }
 
-// Call for existing active window - with error handling
-try {
-    if (workspace.activeClient) {
-        callDBus(
-            "com.k0kubun.XremapHelper",
-            "/com/k0kubun/XremapHelper",
-            "com.k0kubun.XremapHelper",
-            "NotifyActiveWindow",
-            workspace.activeClient.caption,
-            workspace.activeClient.resourceClass,
-            workspace.activeClient.resourceName
-        );
-    }
-} catch (e) {
-    print("Error calling initial active window: " + e);
+if (workspace.activeWindow) {
+    notifyActiveWindow(workspace.activeWindow);
 }
 
-if (workspace.windowList) {
-    workspace.windowActivated.connect(notifyActiveWindow);
-} else {
-    workspace.clientActivated.connect(notifyActiveWindow);
-}
+workspace.windowActivated.connect(notifyActiveWindow);
 
-print("KWin script loaded and connected to workspace");
+print("xremap-helper: KWin script loaded successfully");
 '''
 
-        # Write script to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
-            f.write(script_code)
-            self.kwin_script_path = f.name
-            log.info(f"KWin script written to: {self.kwin_script_path}")
+SCRIPT_NAME = 'xremap-helper'
 
-        # Try loading with retries
+
+class DBusHelper:
+    """Helper class for D-Bus operations."""
+    
+    def __init__(self):
+        self._bus: Optional[dbus.SessionBus] = None
+    
+    @property
+    def bus(self) -> dbus.SessionBus:
+        if self._bus is None:
+            self._bus = dbus.SessionBus()
+        return self._bus
+    
+    def call(self, object_path: str, interface: str, method_name: str,
+             signature: str = '', args: tuple = (), 
+             service: str = 'org.kde.KWin') -> Any:
+        """Make a D-Bus call with explicit signature."""
+        return self.bus.call_blocking(
+            service, object_path, interface, method_name, signature, args
+        )
+    
+    def call_kwin_scripting(self, method_name: str, signature: str = '', 
+                            args: tuple = ()) -> Any:
+        """Call a method on the KWin Scripting interface."""
+        return self.call('/Scripting', 'org.kde.kwin.Scripting', 
+                        method_name, signature, args)
+    
+    def call_script(self, object_path: str, method_name: str, 
+                    signature: str = '', args: tuple = ()) -> Any:
+        """Call a method on a KWin Script interface."""
+        return self.call(object_path, 'org.kde.kwin.Script', 
+                        method_name, signature, args)
+    
+    def introspect(self, object_path: str) -> str:
+        """Introspect a D-Bus object and return XML."""
+        obj = self.bus.get_object('org.kde.KWin', object_path)
+        iface = dbus.Interface(obj, 'org.freedesktop.DBus.Introspectable')
+        return iface.Introspect()
+    
+    def get_child_nodes(self, object_path: str) -> list[str]:
+        """Get child node names from introspection."""
+        try:
+            xml = self.introspect(object_path)
+            return re.findall(r'<node name="([^"]+)"', xml)
+        except dbus.exceptions.DBusException:
+            return []
+
+
+class KdeSocketHelper:
+    def __init__(self, socket_path: str):
+        self.socket_path = Path(socket_path)
+        self.socket_dir = self.socket_path.parent
+        self.server_socket: Optional[socket.socket] = None
+        self.running = False
+        self.clients: list[socket.socket] = []
+        self.current_window: dict = {'caption': '', 'class': '', 'app_id': ''}
+        self.kwin_script_path: Optional[str] = None
+        self.kwin_script_id: Optional[int] = None
+        self.dbus = DBusHelper()
+
+    def setup(self):
+        """Create socket directory and socket."""
+        self.socket_dir = self._get_socket_directory()
+        self.socket_path = self.socket_dir / "kde.sock"
+        
+        self._remove_existing_socket()
+        self._create_server_socket()
+        self._setup_socket_watcher()
+
+    def _get_socket_directory(self) -> Path:
+        """Determine and create the appropriate socket directory."""
+        primary_dir = Path("/run/xremap")
+        fallback_dir = Path(f"/run/user/{os.getuid()}/xremap")
+        
+        if self._try_setup_directory(primary_dir):
+            return primary_dir
+        
+        self._try_setup_directory(fallback_dir, must_succeed=True)
+        log.warning(f"Using fallback directory {fallback_dir}")
+        return fallback_dir
+
+    def _try_setup_directory(self, directory: Path, must_succeed: bool = False) -> bool:
+        """Try to set up a directory, return True on success."""
+        try:
+            if not directory.exists():
+                directory.mkdir(parents=True, exist_ok=True)
+                os.chmod(str(directory), 0o755)
+                log.info(f"Created directory {directory}")
+            elif os.access(str(directory), os.W_OK):
+                log.info(f"Using existing directory {directory}")
+            else:
+                return False
+            return True
+        except PermissionError:
+            if must_succeed:
+                raise
+            return False
+
+    def _remove_existing_socket(self):
+        """Remove existing socket file if present."""
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+
+    def _create_server_socket(self):
+        """Create and configure the Unix server socket."""
+        self.server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.server_socket.bind(str(self.socket_path))
+        os.chmod(str(self.socket_path), 0o666)
+        self.server_socket.listen(5)
+        self.server_socket.setblocking(False)
+        
+        log.info(f"Socket created at {self.socket_path} (mode 666)")
+        log.info(f"Listening on {self.socket_path}")
+        print(f"SOCKET_PATH={self.socket_path}")
+
+    def _setup_socket_watcher(self):
+        """Set up GLib watch for incoming connections."""
+        GLib.io_add_watch(
+            self.server_socket.fileno(),
+            GLib.IO_IN,
+            self._handle_connection
+        )
+
+    def _handle_connection(self, fd, condition) -> bool:
+        """Handle new client connection."""
+        if condition & GLib.IO_IN:
+            try:
+                client_socket, _ = self.server_socket.accept()
+                client_socket.setblocking(False)
+                self.clients.append(client_socket)
+                log.info(f"Client connected (total: {len(self.clients)})")
+                self.broadcast_window_info()
+            except BlockingIOError:
+                pass
+        return True
+
+    def notify_active_window(self, caption: str, res_class: str, res_name: str):
+        """Update current window info and broadcast to clients."""
+        self.current_window = {
+            'caption': caption,
+            'class': res_class,
+            'app_id': res_name
+        }
+        self.broadcast_window_info()
+
+    def broadcast_window_info(self):
+        """Send window info to all connected clients."""
+        if not self.clients:
+            return
+
+        message = json.dumps(self.current_window, ensure_ascii=False) + '\n'
+        message_bytes = message.encode('utf-8')
+        
+        self.clients = [
+            client for client in self.clients 
+            if self._send_to_client(client, message_bytes)
+        ]
+
+    def _send_to_client(self, client: socket.socket, data: bytes) -> bool:
+        """Send data to a client, return True if successful."""
+        try:
+            client.sendall(data)
+            return True
+        except (BrokenPipeError, ConnectionResetError, OSError) as e:
+            log.debug(f"Removing disconnected client: {e}")
+            self._close_client(client)
+            return False
+
+    def _close_client(self, client: socket.socket):
+        """Safely close a client socket."""
+        try:
+            client.close()
+        except OSError:
+            pass
+
+    def _unload_existing_script(self) -> bool:
+        """Try to unload any existing xremap-helper script."""
+        try:
+            self.dbus.call_kwin_scripting('unloadScript', 's', (SCRIPT_NAME,))
+            log.info(f"Unloaded existing {SCRIPT_NAME} script")
+            time.sleep(0.5)
+            return True
+        except dbus.exceptions.DBusException as e:
+            log.debug(f"No existing script to unload: {e}")
+            return False
+
+    def _write_script_file(self) -> str:
+        """Write the KWin script to a temp file and return the path."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
+            f.write(KWIN_SCRIPT_CODE)
+            log.info(f"KWin script written to: {f.name}")
+            return f.name
+
+    def _load_script(self) -> Optional[int]:
+        """Load the script into KWin, return script ID or None."""
+        try:
+            script_id = self.dbus.call_kwin_scripting(
+                'loadScript', 'ss', (self.kwin_script_path, SCRIPT_NAME)
+            )
+            return int(script_id)
+        except dbus.exceptions.DBusException as e:
+            log.error(f"loadScript failed: {e}")
+            return None
+
+    def _try_run_script(self, script_id: int) -> bool:
+        """Try to run script at the expected Plasma 6 path."""
+        path = f'/Scripting/Script{script_id}'
+        try:
+            self.dbus.call_script(path, 'run')
+            log.info(f"KWin script started successfully at {path}")
+            return True
+        except dbus.exceptions.DBusException as e:
+            log.debug(f"Failed to start script at {path}: {e}")
+            return False
+
+    def _try_run_script_via_introspection(self) -> bool:
+        """Try to find and run script by introspecting available nodes."""
+        log.warning("Standard path failed, trying introspection...")
+        
+        nodes = self.dbus.get_child_nodes('/Scripting')
+        log.info(f"Found scripting child nodes: {nodes}")
+        
+        for node in nodes:
+            if 'Script' in node or node.isdigit():
+                path = f'/Scripting/{node}'
+                try:
+                    self.dbus.call_script(path, 'run')
+                    log.info(f"KWin script started at {path}")
+                    return True
+                except dbus.exceptions.DBusException as e:
+                    log.debug(f"Failed at {path}: {e}")
+        
+        return False
+
+    def load_kwin_script(self, max_retries: int = 5, retry_delay: int = 2) -> bool:
+        """Load KWin script using D-Bus, with retries for boot-time availability."""
+        self.kwin_script_path = self._write_script_file()
+
         for attempt in range(1, max_retries + 1):
             try:
-                # Use qdbus to load and start script
-                # Load script
-                result = subprocess.run(
-                    ['qdbus', 'org.kde.KWin', '/Scripting', 'org.kde.kwin.Scripting.loadScript',
-                     self.kwin_script_path, 'xremap-helper'],
-                    capture_output=True,
-                    text=True
-                )
-
-                if result.returncode != 0:
-                    if attempt < max_retries:
-                        log.warning(f"Attempt {attempt}/{max_retries}: qdbus loadScript failed: {result.stderr}")
-                        log.info(f"Retrying in {retry_delay} seconds...")
-                        time.sleep(retry_delay)
-                        continue
-                    else:
-                        log.error(f"qdbus loadScript failed after {max_retries} attempts: {result.stderr}")
-                        return False
-
-                # Script loaded successfully
-                script_id_str = result.stdout.strip()
-                log.info(f"Raw script ID from qdbus: '{script_id_str}'")
-
+                # Verify KWin is available
                 try:
-                    script_id = int(script_id_str)
-                except ValueError:
-                    log.error(f"Invalid script ID: {script_id_str}")
-                    return False
+                    self.dbus.bus.get_object('org.kde.KWin', '/Scripting')
+                except dbus.exceptions.DBusException as e:
+                    raise RuntimeError(f"Could not connect to KWin Scripting: {e}")
+
+                # Unload existing script and load new one
+                self._unload_existing_script()
+                script_id = self._load_script()
+
+                if script_id is None:
+                    raise RuntimeError("loadScript returned None")
+
+                log.info(f"Script ID from D-Bus: {script_id}")
 
                 if script_id < 0:
-                    log.error(f"Script load returned negative ID: {script_id} - likely script execution error")
-                    # Still try to start it
-                    script_id = abs(script_id)
+                    raise RuntimeError(f"Script load failed with ID {script_id}")
 
-                log.info(f"Loaded KWin script with ID: {script_id}")
                 self.kwin_script_id = script_id
 
-                # Start script - try different object paths for KDE5/KDE6
-                for obj_path_fn in [lambda i: f'/{i}', lambda i: f'/Scripting/Script{i}']:
-                    obj_path = obj_path_fn(self.kwin_script_id)
-                    result = subprocess.run(
-                        ['qdbus', 'org.kde.KWin', obj_path, 'org.kde.kwin.Script.run'],
-                        capture_output=True,
-                        text=True
-                    )
+                # Try to run the script
+                if self._try_run_script(script_id):
+                    return True
+                
+                # Fallback to introspection
+                if self._try_run_script_via_introspection():
+                    return True
 
-                    if result.returncode == 0:
-                        log.info(f"KWin script started successfully at {obj_path}")
-                        if result.stderr:
-                            log.debug(f"Script stderr: {result.stderr}")
-                        return True
-                    else:
-                        log.debug(f"Failed to start script at {obj_path}: {result.stderr}")
-
-                log.error("Failed to start KWin script")
-                return False
+                raise RuntimeError("Failed to start KWin script")
 
             except Exception as e:
                 if attempt < max_retries:
-                    log.warning(f"Attempt {attempt}/{max_retries}: Exception during KWin script loading: {e}")
+                    log.warning(f"Attempt {attempt}/{max_retries}: {e}")
                     log.info(f"Retrying in {retry_delay} seconds...")
                     time.sleep(retry_delay)
-                    continue
                 else:
                     log.error(f"Failed to load KWin script after {max_retries} attempts: {e}")
-                    import traceback
-                    log.error(traceback.format_exc())
                     return False
 
-        log.error(f"Failed to load KWin script after {max_retries} attempts")
         return False
 
     def cleanup_kwin_script(self):
-        """Unload KWin script"""
-        if not self.kwin_script_id:
-            return
+        """Unload KWin script and clean up temp file."""
+        if self.kwin_script_id is not None:
+            try:
+                self.dbus.call_kwin_scripting('unloadScript', 's', (SCRIPT_NAME,))
+                log.info("KWin script unloaded")
+            except Exception as e:
+                log.error(f"Failed to unload KWin script: {e}")
 
-        try:
-            bus = dbus.SessionBus()
-            kwin_scripting = bus.get_object('org.kde.KWin', '/Scripting')
-            scripting_interface = dbus.Interface(kwin_scripting, 'org.kde.kwin.Scripting')
-            scripting_interface.unloadScript('xremap-helper')
-            log.info("KWin script unloaded")
-        except Exception as e:
-            log.error(f"Failed to unload KWin script: {e}")
-
-        # Clean up temp file
         if self.kwin_script_path and os.path.exists(self.kwin_script_path):
             try:
                 os.unlink(self.kwin_script_path)
-            except:
+            except OSError:
                 pass
 
     def cleanup(self):
-        """Clean up resources"""
-        # Close all client connections
+        """Clean up all resources."""
         for client in self.clients:
-            try:
-                client.close()
-            except:
-                pass
+            self._close_client(client)
         self.clients.clear()
 
         if self.server_socket:
@@ -323,82 +375,63 @@ print("KWin script loaded and connected to workspace");
             self.socket_path.unlink()
             log.info(f"Removed socket {self.socket_path}")
 
-        # Cleanup KWin script
         self.cleanup_kwin_script()
 
     def run(self):
-        """Main loop (GLib event loop)"""
+        """Main loop (GLib event loop)."""
         self.running = True
-
         log.info("Starting KDE socket helper...")
 
-        # Load KWin script
         if not self.load_kwin_script():
             log.error("Could not load KWin script, continuing anyway...")
 
-        # Create GLib main loop
         loop = GLib.MainLoop()
 
-        # Set up signal handlers using GLib (works better with GLib main loop)
         def signal_handler(signum):
             log.info(f"Received signal {signum}, shutting down...")
             self.running = False
-            # Cleanup before quitting
             self.cleanup()
-            # Quit main loop (not a new instance!)
             loop.quit()
 
-        # Watch for SIGTERM and SIGINT using GLib's signal handling
-        # Pass signal number as user_data so handler receives it
         GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGTERM, signal_handler, signal.SIGTERM)
         GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGINT, signal_handler, signal.SIGINT)
 
-        # Run main loop
         loop.run()
 
 
 class DBusService(Object):
-    """D-Bus service that KWin scripts can call"""
+    """D-Bus service that KWin scripts can call."""
 
     def __init__(self, helper: KdeSocketHelper):
-        # Set up D-Bus main loop for GLib
         from dbus.mainloop.glib import DBusGMainLoop
         DBusGMainLoop(set_as_default=True)
 
-        # Create bus name and object
         bus_name = BusName("com.k0kubun.XremapHelper", bus=dbus.SessionBus())
-        Object.__init__(
-            self,
-            bus_name,
-            "/com/k0kubun/XremapHelper"
-        )
+        Object.__init__(self, bus_name, "/com/k0kubun/XremapHelper")
         self.helper = helper
 
     @method("com.k0kubun.XremapHelper")
     def NotifyActiveWindow(self, caption: str, res_class: str, res_name: str):
-        """Notify about active window change - called by KWin script"""
+        """Notify about active window change - called by KWin script."""
         log.debug(f"Received: caption='{caption}', class='{res_class}', name='{res_name}'")
         self.helper.notify_active_window(caption, res_class, res_name)
 
 
 def main():
-    parser = argparse.ArgumentParser(description='KDE socket helper for xremap')
-    parser.add_argument('--socket-path',
-                        default='/run/xremap/kde.sock',
-                        help='Path to Unix socket (default: /run/xremap/kde.sock)')
+    parser = argparse.ArgumentParser(description='KDE Plasma 6 socket helper for xremap')
+    parser.add_argument(
+        '--socket-path',
+        default='/run/xremap/kde.sock',
+        help='Path to Unix socket (default: /run/xremap/kde.sock)'
+    )
     args = parser.parse_args()
 
-    # Create helper instance
     helper = KdeSocketHelper(args.socket_path)
-
-    # Setup socket
     helper.setup()
 
-    # Register D-Bus service
     log.info("Registered D-Bus service com.k0kubun.XremapHelper")
     DBusService(helper)
 
-    # Run main loop
     helper.run()
 
 

--- a/doc/kde-wayland/kde-socket-helper.py
+++ b/doc/kde-wayland/kde-socket-helper.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""
+KDE socket helper for xremap.
+Provides window information via Unix socket to avoid D-Bus EXTERNAL authentication issues.
+"""
+
+import argparse
+import json
+import logging
+import os
+import signal
+import socket
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import dbus
+import dbus.mainloop.glib
+from dbus.service import Object, method, BusName
+from gi.repository import GLib
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s: %(message)s',
+    stream=sys.stdout
+)
+log = logging.getLogger('xremap-kde')
+
+
+class KdeSocketHelper:
+    def __init__(self, socket_path: str):
+        self.socket_path = Path(socket_path)
+        self.socket_dir = self.socket_path.parent
+        self.server_socket: Optional[socket.socket] = None
+        self.running = False
+        self.clients: list[socket.socket] = []
+        self.current_window: dict = {
+            'caption': '',
+            'class': '',
+            'app_id': ''
+        }
+        self.kwin_script_path = None
+        self.kwin_script_id = None
+
+    def setup(self):
+        """Create socket directory and socket"""
+        import pwd
+
+        # Use system-wide runtime directory for cross-user access
+        self.socket_dir = Path("/run/xremap")
+
+        # Only try to create /run/xremap if it doesn't exist
+        if not self.socket_dir.exists():
+            try:
+                self.socket_dir.mkdir(parents=True, exist_ok=True)
+                # Set permissions to allow xremap user to access
+                os.chmod(str(self.socket_dir), 0o755)
+                log.info(f"Created directory {self.socket_dir}")
+            except PermissionError:
+                # If we can't create /run/xremap (as user), fall back to user runtime
+                uid = os.getuid()
+                self.socket_dir = Path(f"/run/user/{uid}/xremap")
+                self.socket_dir.mkdir(parents=True, exist_ok=True)
+                os.chmod(str(self.socket_dir), 0o755)
+                log.warning(f"Could not create /run/xremap, using {self.socket_dir} instead")
+        else:
+            # Directory exists, verify we can write to it
+            if os.access(str(self.socket_dir), os.W_OK):
+                log.info(f"Using existing directory {self.socket_dir}")
+            else:
+                # Can't write to /run/xremap, fall back to user runtime
+                uid = os.getuid()
+                self.socket_dir = Path(f"/run/user/{uid}/xremap")
+                self.socket_dir.mkdir(parents=True, exist_ok=True)
+                os.chmod(str(self.socket_dir), 0o755)
+                log.warning(f"Cannot write to /run/xremap, using {self.socket_dir} instead")
+
+        self.socket_path = self.socket_dir / "kde.sock"
+
+        # Remove existing socket if present
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+
+        # Create Unix socket
+        self.server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.server_socket.bind(str(self.socket_path))
+
+        # Set permissions to allow xremap user to connect
+        os.chmod(str(self.socket_path), 0o666)
+        log.info(f"Socket created at {self.socket_path} (mode 666 for universal access)")
+
+        # Listen for connections
+        self.server_socket.listen(5)
+        self.server_socket.setblocking(False)
+        log.info(f"Listening on {self.socket_path}")
+        # Print socket path for easy reference
+        print(f"SOCKET_PATH={self.socket_path}")
+
+        # Setup GLib watch for incoming connections
+        GLib.io_add_watch(
+            self.server_socket.fileno(),
+            GLib.IO_IN,
+            self.handle_connection
+        )
+
+    def handle_connection(self, fd, condition):
+        """Handle new connection"""
+        if condition & GLib.IO_IN:
+            try:
+                client_socket, _ = self.server_socket.accept()
+                client_socket.setblocking(False)
+                self.clients.append(client_socket)
+                log.info(f"Client connected (total: {len(self.clients)})")
+
+                # Send current window info immediately
+                self.broadcast_window_info()
+            except BlockingIOError:
+                pass
+        return True
+
+    def notify_active_window(self, caption: str, res_class: str, res_name: str):
+        """Called by KWin script via D-Bus"""
+        self.current_window = {
+            'caption': caption,
+            'class': res_class,
+            'app_id': res_name
+        }
+        self.broadcast_window_info()
+
+    def broadcast_window_info(self):
+        """Send window info to all connected clients"""
+        if not self.clients:
+            return
+
+        # Use JSON format for robustness (handles special characters, quotes, etc.)
+        data = json.dumps(self.current_window, ensure_ascii=False)
+        message = f"{data}\n"
+
+        # Send to all clients, removing any that fail
+        remaining_clients = []
+        for client in self.clients:
+            try:
+                client.sendall(message.encode('utf-8'))
+                remaining_clients.append(client)
+            except (BrokenPipeError, ConnectionResetError, OSError) as e:
+                log.debug(f"Removing disconnected client: {e}")
+                try:
+                    client.close()
+                except:
+                    pass
+
+        self.clients = remaining_clients
+
+    def load_kwin_script(self, max_retries=5, retry_delay=2):
+        """Load KWin script using qdbus, with retries for boot-time availability"""
+        import subprocess
+        import time
+
+        script_code = '''function notifyActiveWindow(client) {
+    if (!client) {
+        return;
+    }
+
+    try {
+        callDBus(
+            "com.k0kubun.XremapHelper",
+            "/com/k0kubun/XremapHelper",
+            "com.k0kubun.XremapHelper",
+            "NotifyActiveWindow",
+            "caption" in client ? client.caption : "",
+            "resourceClass" in client ? client.resourceClass : "",
+            "resourceName" in client ? client.resourceName : ""
+        );
+    } catch (e) {
+        print("Error in notifyActiveWindow: " + e);
+    }
+}
+
+// Call for existing active window - with error handling
+try {
+    if (workspace.activeClient) {
+        callDBus(
+            "com.k0kubun.XremapHelper",
+            "/com/k0kubun/XremapHelper",
+            "com.k0kubun.XremapHelper",
+            "NotifyActiveWindow",
+            workspace.activeClient.caption,
+            workspace.activeClient.resourceClass,
+            workspace.activeClient.resourceName
+        );
+    }
+} catch (e) {
+    print("Error calling initial active window: " + e);
+}
+
+if (workspace.windowList) {
+    workspace.windowActivated.connect(notifyActiveWindow);
+} else {
+    workspace.clientActivated.connect(notifyActiveWindow);
+}
+
+print("KWin script loaded and connected to workspace");
+'''
+
+        # Write script to temp file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
+            f.write(script_code)
+            self.kwin_script_path = f.name
+            log.info(f"KWin script written to: {self.kwin_script_path}")
+
+        # Try loading with retries
+        for attempt in range(1, max_retries + 1):
+            try:
+                # Use qdbus to load and start script
+                # Load script
+                result = subprocess.run(
+                    ['qdbus', 'org.kde.KWin', '/Scripting', 'org.kde.kwin.Scripting.loadScript',
+                     self.kwin_script_path, 'xremap-helper'],
+                    capture_output=True,
+                    text=True
+                )
+
+                if result.returncode != 0:
+                    if attempt < max_retries:
+                        log.warning(f"Attempt {attempt}/{max_retries}: qdbus loadScript failed: {result.stderr}")
+                        log.info(f"Retrying in {retry_delay} seconds...")
+                        time.sleep(retry_delay)
+                        continue
+                    else:
+                        log.error(f"qdbus loadScript failed after {max_retries} attempts: {result.stderr}")
+                        return False
+
+                # Script loaded successfully
+                script_id_str = result.stdout.strip()
+                log.info(f"Raw script ID from qdbus: '{script_id_str}'")
+
+                try:
+                    script_id = int(script_id_str)
+                except ValueError:
+                    log.error(f"Invalid script ID: {script_id_str}")
+                    return False
+
+                if script_id < 0:
+                    log.error(f"Script load returned negative ID: {script_id} - likely script execution error")
+                    # Still try to start it
+                    script_id = abs(script_id)
+
+                log.info(f"Loaded KWin script with ID: {script_id}")
+                self.kwin_script_id = script_id
+
+                # Start script - try different object paths for KDE5/KDE6
+                for obj_path_fn in [lambda i: f'/{i}', lambda i: f'/Scripting/Script{i}']:
+                    obj_path = obj_path_fn(self.kwin_script_id)
+                    result = subprocess.run(
+                        ['qdbus', 'org.kde.KWin', obj_path, 'org.kde.kwin.Script.run'],
+                        capture_output=True,
+                        text=True
+                    )
+
+                    if result.returncode == 0:
+                        log.info(f"KWin script started successfully at {obj_path}")
+                        if result.stderr:
+                            log.debug(f"Script stderr: {result.stderr}")
+                        return True
+                    else:
+                        log.debug(f"Failed to start script at {obj_path}: {result.stderr}")
+
+                log.error("Failed to start KWin script")
+                return False
+
+            except Exception as e:
+                if attempt < max_retries:
+                    log.warning(f"Attempt {attempt}/{max_retries}: Exception during KWin script loading: {e}")
+                    log.info(f"Retrying in {retry_delay} seconds...")
+                    time.sleep(retry_delay)
+                    continue
+                else:
+                    log.error(f"Failed to load KWin script after {max_retries} attempts: {e}")
+                    import traceback
+                    log.error(traceback.format_exc())
+                    return False
+
+        log.error(f"Failed to load KWin script after {max_retries} attempts")
+        return False
+
+    def cleanup_kwin_script(self):
+        """Unload KWin script"""
+        if not self.kwin_script_id:
+            return
+
+        try:
+            bus = dbus.SessionBus()
+            kwin_scripting = bus.get_object('org.kde.KWin', '/Scripting')
+            scripting_interface = dbus.Interface(kwin_scripting, 'org.kde.kwin.Scripting')
+            scripting_interface.unloadScript('xremap-helper')
+            log.info("KWin script unloaded")
+        except Exception as e:
+            log.error(f"Failed to unload KWin script: {e}")
+
+        # Clean up temp file
+        if self.kwin_script_path and os.path.exists(self.kwin_script_path):
+            try:
+                os.unlink(self.kwin_script_path)
+            except:
+                pass
+
+    def cleanup(self):
+        """Clean up resources"""
+        # Close all client connections
+        for client in self.clients:
+            try:
+                client.close()
+            except:
+                pass
+        self.clients.clear()
+
+        if self.server_socket:
+            self.server_socket.close()
+
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+            log.info(f"Removed socket {self.socket_path}")
+
+        # Cleanup KWin script
+        self.cleanup_kwin_script()
+
+    def run(self):
+        """Main loop (GLib event loop)"""
+        self.running = True
+
+        log.info("Starting KDE socket helper...")
+
+        # Load KWin script
+        if not self.load_kwin_script():
+            log.error("Could not load KWin script, continuing anyway...")
+
+        # Create GLib main loop
+        loop = GLib.MainLoop()
+
+        # Set up signal handlers using GLib (works better with GLib main loop)
+        def signal_handler(signum):
+            log.info(f"Received signal {signum}, shutting down...")
+            self.running = False
+            # Cleanup before quitting
+            self.cleanup()
+            # Quit main loop (not a new instance!)
+            loop.quit()
+
+        # Watch for SIGTERM and SIGINT using GLib's signal handling
+        # Pass signal number as user_data so handler receives it
+        GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGTERM, signal_handler, signal.SIGTERM)
+        GLib.unix_signal_add(GLib.PRIORITY_HIGH, signal.SIGINT, signal_handler, signal.SIGINT)
+
+        # Run main loop
+        loop.run()
+
+
+class DBusService(Object):
+    """D-Bus service that KWin scripts can call"""
+
+    def __init__(self, helper: KdeSocketHelper):
+        # Set up D-Bus main loop for GLib
+        from dbus.mainloop.glib import DBusGMainLoop
+        DBusGMainLoop(set_as_default=True)
+
+        # Create bus name and object
+        bus_name = BusName("com.k0kubun.XremapHelper", bus=dbus.SessionBus())
+        Object.__init__(
+            self,
+            bus_name,
+            "/com/k0kubun/XremapHelper"
+        )
+        self.helper = helper
+
+    @method("com.k0kubun.XremapHelper")
+    def NotifyActiveWindow(self, caption: str, res_class: str, res_name: str):
+        """Notify about active window change - called by KWin script"""
+        log.debug(f"Received: caption='{caption}', class='{res_class}', name='{res_name}'")
+        self.helper.notify_active_window(caption, res_class, res_name)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='KDE socket helper for xremap')
+    parser.add_argument('--socket-path',
+                        default='/run/xremap/kde.sock',
+                        help='Path to Unix socket (default: /run/xremap/kde.sock)')
+    args = parser.parse_args()
+
+    # Create helper instance
+    helper = KdeSocketHelper(args.socket_path)
+
+    # Setup socket
+    helper.setup()
+
+    # Register D-Bus service
+    log.info("Registered D-Bus service com.k0kubun.XremapHelper")
+    DBusService(helper)
+
+    # Run main loop
+    helper.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/doc/kde-wayland/kde-socket-helper.service
+++ b/doc/kde-wayland/kde-socket-helper.service
@@ -1,11 +1,10 @@
 [Unit]
 Description=Xremap KDE Socket Helper
-Wants=graphical.target
-After=graphical.target
+After=graphical-session.target
+Requires=graphical-session.target
 
 [Service]
 Type=simple
-User=parallels
 ExecStart=/usr/local/bin/kde-socket-helper
 Restart=always
 RestartSec=5
@@ -16,4 +15,4 @@ StandardOutput=journal
 StandardError=journal
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target

--- a/doc/kde-wayland/kde-socket-helper.service
+++ b/doc/kde-wayland/kde-socket-helper.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Xremap KDE Socket Helper
+Wants=graphical.target
+After=graphical.target
+
+[Service]
+Type=simple
+User=parallels
+ExecStart=/usr/local/bin/kde-socket-helper
+Restart=always
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/doc/kde-wayland/xremap-tmpfiles.conf
+++ b/doc/kde-wayland/xremap-tmpfiles.conf
@@ -1,0 +1,4 @@
+# Create xremap socket directory
+# Owner: root, Group: root, Mode: 1777 (world-writable with sticky bit)
+# Sticky bit prevents users from deleting each other's files
+d /run/xremap 1777 root root -

--- a/doc/kde-wayland/xremap.service
+++ b/doc/kde-wayland/xremap.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Xremap (run as xremap user)
+After=default.target yourusername-user@yourusername.service kde-socket-helper.service systemd-udev-trigger.service systemd-udev-settle.service
+
+[Service]
+Type=simple
+User=xremap
+Group=input
+ExecStart=/usr/bin/xremap --redact --watch=config /etc/xremap/config.yml
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+Environment=RUST_LOG=warn
+Environment=KDE_SOCKET=/run/xremap/kde.sock
+SupplementaryGroups=input
+
+[Install]
+WantedBy=default.target

--- a/doc/kde-wayland/xremap.service
+++ b/doc/kde-wayland/xremap.service
@@ -6,7 +6,7 @@ After=default.target yourusername-user@yourusername.service kde-socket-helper.se
 Type=simple
 User=xremap
 Group=input
-ExecStart=/usr/bin/xremap --redact --watch=config /etc/xremap/config.yml
+ExecStart=/usr/bin/xremap --watch=config /etc/xremap/config.yml
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -16,16 +16,18 @@ pub struct WMClient {
     supported: Option<bool>,
     last_application: String,
     last_window: String,
+    log_window_changes: bool,
 }
 
 impl WMClient {
-    pub fn new(name: &str, client: Box<dyn Client>) -> WMClient {
+    pub fn new(name: &str, client: Box<dyn Client>, log_window_changes: bool) -> WMClient {
         WMClient {
             name: name.to_string(),
             client,
             supported: None,
             last_application: String::new(),
             last_window: String::new(),
+            log_window_changes,
         }
     }
 
@@ -45,7 +47,9 @@ impl WMClient {
         if let Some(window) = &result {
             if &self.last_window != window {
                 self.last_window = window.clone();
-                println!("window: {window}");
+                if self.log_window_changes {
+                    println!("window: {window}");
+                }
             }
         }
         result
@@ -58,7 +62,9 @@ impl WMClient {
         if let Some(application) = &result {
             if &self.last_application != application {
                 self.last_application = application.clone();
-                println!("application: {application}");
+                if self.log_window_changes {
+                    println!("application: {application}");
+                }
             }
         }
         result
@@ -75,43 +81,43 @@ impl WMClient {
 #[cfg(feature = "gnome")]
 mod gnome_client;
 #[cfg(feature = "gnome")]
-pub fn build_client(_redact: bool) -> WMClient {
-    WMClient::new("GNOME", Box::new(gnome_client::GnomeClient::new()))
+pub fn build_client(_log_window_changes: bool) -> WMClient {
+    WMClient::new("GNOME", Box::new(gnome_client::GnomeClient::new()), _log_window_changes)
 }
 
 #[cfg(feature = "kde")]
 mod kde_client;
 #[cfg(feature = "kde")]
-pub fn build_client(redact: bool) -> WMClient {
-    WMClient::new("KDE", Box::new(kde_client::KdeClient::new(redact)))
+pub fn build_client(log_window_changes: bool) -> WMClient {
+    WMClient::new("KDE", Box::new(kde_client::KdeClient::new(log_window_changes)), log_window_changes)
 }
 
 #[cfg(feature = "hypr")]
 mod hypr_client;
 #[cfg(feature = "hypr")]
-pub fn build_client(_redact: bool) -> WMClient {
-    WMClient::new("Hypr", Box::new(hypr_client::HyprlandClient::new()))
+pub fn build_client(_log_window_changes: bool) -> WMClient {
+    WMClient::new("Hypr", Box::new(hypr_client::HyprlandClient::new()), _log_window_changes)
 }
 
 #[cfg(feature = "x11")]
 mod x11_client;
 #[cfg(feature = "x11")]
-pub fn build_client(_redact: bool) -> WMClient {
-    WMClient::new("X11", Box::new(x11_client::X11Client::new()))
+pub fn build_client(_log_window_changes: bool) -> WMClient {
+    WMClient::new("X11", Box::new(x11_client::X11Client::new()), _log_window_changes)
 }
 
 #[cfg(feature = "wlroots")]
 mod wlroots_client;
 #[cfg(feature = "wlroots")]
-pub fn build_client(_redact: bool) -> WMClient {
-    WMClient::new("wlroots", Box::new(wlroots_client::WlRootsClient::new()))
+pub fn build_client(_log_window_changes: bool) -> WMClient {
+    WMClient::new("wlroots", Box::new(wlroots_client::WlRootsClient::new()), _log_window_changes)
 }
 
 #[cfg(feature = "niri")]
 mod niri_client;
 #[cfg(feature = "niri")]
-pub fn build_client(_redact: bool) -> WMClient {
-    WMClient::new("Niri", Box::new(niri_client::NiriClient::new()))
+pub fn build_client(_log_window_changes: bool) -> WMClient {
+    WMClient::new("Niri", Box::new(niri_client::NiriClient::new()), _log_window_changes)
 }
 
 #[cfg(feature = "cosmic")]
@@ -119,8 +125,8 @@ mod cosmic_client;
 #[cfg(feature = "cosmic")]
 mod cosmic_protocols;
 #[cfg(feature = "cosmic")]
-pub fn build_client(_redact: bool) -> WMClient {
-    WMClient::new("Cosmic", Box::new(cosmic_client::CosmicClient::new()))
+pub fn build_client(_log_window_changes: bool) -> WMClient {
+    WMClient::new("Cosmic", Box::new(cosmic_client::CosmicClient::new()), _log_window_changes)
 }
 
 #[cfg(not(any(
@@ -142,6 +148,6 @@ mod null_client;
     feature = "niri",
     feature = "cosmic"
 )))]
-pub fn build_client(_redact: bool) -> WMClient {
-    WMClient::new("none", Box::new(null_client::NullClient))
+pub fn build_client(_log_window_changes: bool) -> WMClient {
+    WMClient::new("none", Box::new(null_client::NullClient), _log_window_changes)
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -75,42 +75,42 @@ impl WMClient {
 #[cfg(feature = "gnome")]
 mod gnome_client;
 #[cfg(feature = "gnome")]
-pub fn build_client() -> WMClient {
+pub fn build_client(_redact: bool) -> WMClient {
     WMClient::new("GNOME", Box::new(gnome_client::GnomeClient::new()))
 }
 
 #[cfg(feature = "kde")]
 mod kde_client;
 #[cfg(feature = "kde")]
-pub fn build_client() -> WMClient {
-    WMClient::new("KDE", Box::new(kde_client::KdeClient::new()))
+pub fn build_client(redact: bool) -> WMClient {
+    WMClient::new("KDE", Box::new(kde_client::KdeClient::new(redact)))
 }
 
 #[cfg(feature = "hypr")]
 mod hypr_client;
 #[cfg(feature = "hypr")]
-pub fn build_client() -> WMClient {
+pub fn build_client(_redact: bool) -> WMClient {
     WMClient::new("Hypr", Box::new(hypr_client::HyprlandClient::new()))
 }
 
 #[cfg(feature = "x11")]
 mod x11_client;
 #[cfg(feature = "x11")]
-pub fn build_client() -> WMClient {
+pub fn build_client(_redact: bool) -> WMClient {
     WMClient::new("X11", Box::new(x11_client::X11Client::new()))
 }
 
 #[cfg(feature = "wlroots")]
 mod wlroots_client;
 #[cfg(feature = "wlroots")]
-pub fn build_client() -> WMClient {
+pub fn build_client(_redact: bool) -> WMClient {
     WMClient::new("wlroots", Box::new(wlroots_client::WlRootsClient::new()))
 }
 
 #[cfg(feature = "niri")]
 mod niri_client;
 #[cfg(feature = "niri")]
-pub fn build_client() -> WMClient {
+pub fn build_client(_redact: bool) -> WMClient {
     WMClient::new("Niri", Box::new(niri_client::NiriClient::new()))
 }
 
@@ -119,7 +119,7 @@ mod cosmic_client;
 #[cfg(feature = "cosmic")]
 mod cosmic_protocols;
 #[cfg(feature = "cosmic")]
-pub fn build_client() -> WMClient {
+pub fn build_client(_redact: bool) -> WMClient {
     WMClient::new("Cosmic", Box::new(cosmic_client::CosmicClient::new()))
 }
 
@@ -142,6 +142,6 @@ mod null_client;
     feature = "niri",
     feature = "cosmic"
 )))]
-pub fn build_client() -> WMClient {
+pub fn build_client(_redact: bool) -> WMClient {
     WMClient::new("none", Box::new(null_client::NullClient))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,9 @@ struct Args {
     /// Show device details
     #[arg(long)]
     device_details: bool,
+    /// Redact sensitive information from window captions
+    #[arg(long)]
+    redact: bool,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -140,6 +143,7 @@ fn main() -> anyhow::Result<()> {
         vendor,
         list_devices,
         device_details,
+        redact,
     } = Args::parse();
 
     if let Some(shell) = completions {
@@ -195,7 +199,7 @@ fn main() -> anyhow::Result<()> {
     let device_watcher = device_watcher(watch_devices).context("Setting up device watcher")?;
     let config_watcher = config_watcher(watch_config, &config_paths).context("Setting up config watcher")?;
     let watchers: Vec<_> = device_watcher.iter().chain(config_watcher.iter()).collect();
-    let mut handler = EventHandler::new(timer, &config.default_mode, delay, build_client());
+    let mut handler = EventHandler::new(timer, &config.default_mode, delay, build_client(redact));
     let vendor = u16::from_str_radix(vendor.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x1234);
     let product = u16::from_str_radix(product.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x5678);
     let output_device = match output_device(

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,9 +109,9 @@ struct Args {
     /// Show device details
     #[arg(long)]
     device_details: bool,
-    /// Redact sensitive information from window captions
+    /// Log window and application changes
     #[arg(long)]
-    redact: bool,
+    log_window_changes: bool,
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
@@ -143,7 +143,7 @@ fn main() -> anyhow::Result<()> {
         vendor,
         list_devices,
         device_details,
-        redact,
+        log_window_changes,
     } = Args::parse();
 
     if let Some(shell) = completions {
@@ -199,7 +199,7 @@ fn main() -> anyhow::Result<()> {
     let device_watcher = device_watcher(watch_devices).context("Setting up device watcher")?;
     let config_watcher = config_watcher(watch_config, &config_paths).context("Setting up config watcher")?;
     let watchers: Vec<_> = device_watcher.iter().chain(config_watcher.iter()).collect();
-    let mut handler = EventHandler::new(timer, &config.default_mode, delay, build_client(redact));
+    let mut handler = EventHandler::new(timer, &config.default_mode, delay, build_client(log_window_changes));
     let vendor = u16::from_str_radix(vendor.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x1234);
     let product = u16::from_str_radix(product.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x5678);
     let output_device = match output_device(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -897,7 +897,7 @@ pub fn assert_actions_with_current_application(
         timer,
         &config.default_mode,
         Duration::from_micros(0),
-        WMClient::new("static", Box::new(StaticClient { current_application })),
+        WMClient::new("static", Box::new(StaticClient { current_application }), false),
     );
     let mut actual: Vec<Action> = vec![];
 


### PR DESCRIPTION
Add documentation and implementation for securely running xremap on KDE Plasma Wayland.

This new guide details a setup where xremap runs as a dedicated system user. This architecture isolates input device access, adhering to the principle of least privilege and preventing malicious user applications from logging keystrokes.

It includes instructions for:

- Creating a dedicated system user with access to the `input` group.
- Implementing a socket-based helper to bridge KWin window info to the isolated xremap process for application-specific remapping.
- Configuring systemd services for both the main xremap instance and the helper.

The setup has been tested on Fedora and works across reboots.

I'm opening this PR for feedback. Note that this also has the changes from #821.

**NOTE:** I'm not a Rust or Python developer, these changes were implemented by AI under guidance and testing. Feel free to close this PR or take over.