### PR TITLE
Fix: Anykey in nested remap emits trigger-key on timeout

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -169,7 +169,7 @@ impl EventHandler {
                 self.dispatch_actions(&actions, &key)?;
                 return Ok(true);
             } else if let Some(actions) = self.find_keymap(config, &KEY_MATCH_ANY, device, wmclient)? {
-                self.dispatch_actions(&actions, &KEY_MATCH_ANY)?;
+                self.dispatch_actions(&actions, &key)?;
                 return Ok(true);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,8 @@ mod tests_any_key;
 #[cfg(test)]
 mod tests_disguised_events_in;
 #[cfg(test)]
+mod tests_escape_next_key;
+#[cfg(test)]
 mod tests_extra_modifiers;
 #[cfg(test)]
 mod tests_keymap_mark;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 /// Test cases are placed in the file of the most specific feature they test.
 /// With the following definition of specific (ordered by most specific first):
 ///
+///     Escape Next Key
 ///     Any key
 ///     Virtual modifiers
 ///     Disguised events input (i.e. transformation of relative event to pseudo keys)

--- a/src/tests_any_key.rs
+++ b/src/tests_any_key.rs
@@ -70,6 +70,25 @@ fn test_anykey_can_activate_nested_remap() {
 }
 
 #[test]
+fn test_anykey_when_nested_remap_times_out() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              ANY:
+                timeout_millis: 100
+                remap:
+                  A: B
+        "},
+        vec![Event::key_press(Key::KEY_K), Event::OverrideTimeout],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_K, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_K, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
 fn test_any_does_not_work_in_nested_remap() {
     // This happens because it tries nested with K, and then cancels the nested
     // remap because K is not mapped there. So it doesn't matter that it's later

--- a/src/tests_any_key.rs
+++ b/src/tests_any_key.rs
@@ -1,7 +1,7 @@
 use crate::action::Action;
 use crate::event::{Event, KeyEvent, KeyValue};
 use crate::tests::assert_actions;
-use evdev::KeyCode as Key;
+use evdev::{KeyCode as Key, RelativeAxisCode};
 use indoc::indoc;
 use std::time::Duration;
 
@@ -27,6 +27,44 @@ fn test_any_key() {
             Action::Delay(Duration::from_nanos(0)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
             Action::KeyEvent(KeyEvent::new(Key::KEY_C, KeyValue::Release)),
+        ],
+    );
+}
+
+#[test]
+fn test_disguised_keys_match_any_key() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              ANY: A
+        "},
+        vec![Event::relative(RelativeAxisCode::REL_WHEEL.0, 10)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    );
+}
+
+#[test]
+fn test_anykey_can_activate_nested_remap() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              ANY:
+                remap:
+                  A: B
+        "},
+        vec![Event::key_press(Key::KEY_K), Event::key_press(Key::KEY_A)],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
         ],
     );
 }

--- a/src/tests_escape_next_key.rs
+++ b/src/tests_escape_next_key.rs
@@ -1,0 +1,127 @@
+use crate::action::Action;
+use crate::event::{Event, RelativeEvent};
+use crate::event::{KeyEvent, KeyValue};
+use crate::tests::assert_actions;
+use evdev::{KeyCode as Key, RelativeAxisCode};
+use indoc::indoc;
+
+#[test]
+fn test_escape_next_key() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              esc: { escape_next_key: true }
+              A: C
+        "},
+        vec![Event::key_press(Key::KEY_ESC), Event::key_press(Key::KEY_A)],
+        vec![Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press))],
+    )
+}
+
+#[test]
+fn test_release_does_not_cancel_escape_next_key() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              esc: { escape_next_key: true }
+              A: C
+        "},
+        vec![
+            Event::key_press(Key::KEY_K),
+            Event::key_press(Key::KEY_ESC),
+            Event::key_release(Key::KEY_K),
+            Event::key_press(Key::KEY_A),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_K, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_K, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press)),
+        ],
+    )
+}
+
+#[test]
+fn test_escape_next_disguised_key() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              esc: { escape_next_key: true }
+              XUpScroll: C
+        "},
+        vec![
+            Event::key_press(Key::KEY_ESC),
+            Event::relative(RelativeAxisCode::REL_WHEEL.0, 10),
+        ],
+        vec![Action::RelativeEvent(RelativeEvent::new_with(
+            RelativeAxisCode::REL_WHEEL.0,
+            10,
+        ))],
+    )
+}
+
+#[test]
+fn test_modifier_does_not_affect_escape_next_key() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              esc: { escape_next_key: true }
+              Ctrl_L: A
+              Ctrl_L-B: C
+        "},
+        vec![
+            Event::key_press(Key::KEY_ESC),
+            Event::key_press(Key::KEY_LEFTCTRL),
+            Event::key_press(Key::KEY_B),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+        ],
+    )
+}
+
+#[test]
+fn test_virtual_modifier_does_not_affect_escape_next_key() {
+    assert_actions(
+        indoc! {"
+        virtual_modifiers: [Capslock]
+        keymap:
+          - remap:
+              esc: { escape_next_key: true }
+              Capslock: A
+              Capslock-B: C
+        "},
+        vec![
+            Event::key_press(Key::KEY_ESC),
+            Event::key_press(Key::KEY_CAPSLOCK),
+            Event::key_press(Key::KEY_B),
+        ],
+        vec![Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press))],
+    )
+}
+
+#[test]
+fn test_matching_any_key_does_not_affect_escape_next_key() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              esc: { escape_next_key: true }
+              ANY: A
+              c_l-B: C
+        "},
+        vec![
+            Event::key_press(Key::KEY_ESC),
+            Event::key_press(Key::KEY_LEFTCTRL),
+            Event::key_press(Key::KEY_B),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTCTRL, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_B, KeyValue::Press)),
+        ],
+    )
+}

--- a/src/tests_nested_remap.rs
+++ b/src/tests_nested_remap.rs
@@ -70,6 +70,51 @@ fn test_exact_match_false_nested() {
 }
 
 #[test]
+fn test_nested_remap_with_on_action() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              f12:
+                remap:
+                    A: []
+        "},
+        vec![Event::key_press(Key::KEY_F12), Event::key_press(Key::KEY_A)],
+        vec![],
+    );
+}
+
+#[test]
+fn test_nested_remap_does_not_match_modifiers() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              f12:
+                remap:
+                    C-A: B
+        "},
+        vec![Event::key_press(Key::KEY_F12), Event::key_press(Key::KEY_A)],
+        vec![Action::KeyEvent(KeyEvent::new(Key::KEY_A, KeyValue::Press))],
+    );
+}
+
+#[test]
+fn test_nested_remap_does_not_match_mod_trigger() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              f12:
+                remap:
+                    C-A_L: B
+        "},
+        vec![Event::key_press(Key::KEY_F12), Event::key_press(Key::KEY_LEFTALT)],
+        vec![Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press))],
+    );
+}
+
+#[test]
 fn test_merge_remaps() {
     let config = indoc! {"
         keymap:
@@ -658,4 +703,81 @@ fn test_nested_remap_inexact_when_union_of_modifiers() {
             Action::Delay(Duration::from_nanos(0)),
         ],
     )
+}
+
+#[test]
+fn test_triple_nested_remap() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              A:
+                remap:
+                  B:
+                    remap:
+                      C: D
+        "},
+        vec![
+            Event::key_press(Key::KEY_A),
+            Event::key_press(Key::KEY_B),
+            Event::key_press(Key::KEY_C),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_D, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_D, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    )
+}
+
+#[test]
+fn test_triple_nested_remap_modifier_does_not_cancel_remap() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              A:
+                remap:
+                  B:
+                    remap:
+                      S-C: D
+        "},
+        vec![
+            Event::key_press(Key::KEY_A),
+            Event::key_press(Key::KEY_B),
+            Event::key_press(Key::KEY_LEFTSHIFT),
+            Event::key_press(Key::KEY_C),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Release)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_D, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_D, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTSHIFT, KeyValue::Press)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    )
+}
+
+#[test]
+fn test_triple_nested_remap_does_not_match_modifiers() {
+    assert_actions(
+        indoc! {"
+        keymap:
+          - remap:
+              f12:
+                remap:
+                  A:
+                    remap:
+                      C-A_L: D
+        "},
+        vec![
+            Event::key_press(Key::KEY_F12),
+            Event::key_press(Key::KEY_A),
+            Event::key_press(Key::KEY_LEFTALT),
+        ],
+        vec![Action::KeyEvent(KeyEvent::new(Key::KEY_LEFTALT, KeyValue::Press))],
+    );
 }

--- a/src/tests_virtual_modifier.rs
+++ b/src/tests_virtual_modifier.rs
@@ -198,3 +198,29 @@ fn test_virtual_terminal_modifier_is_not_supported() {
         vec![],
     )
 }
+
+#[test]
+fn test_nested_remap_is_not_cancelled_by_virtual_modifier() {
+    assert_actions(
+        indoc! {"
+        virtual_modifiers:
+            - Capslock
+        keymap:
+            - remap:
+                A:
+                  remap:
+                    Capslock-B: C
+        "},
+        vec![
+            Event::key_press(Key::KEY_A),
+            Event::key_press(Key::KEY_CAPSLOCK),
+            Event::key_press(Key::KEY_B),
+        ],
+        vec![
+            Action::KeyEvent(KeyEvent::new(Key::KEY_C, KeyValue::Press)),
+            Action::KeyEvent(KeyEvent::new(Key::KEY_C, KeyValue::Release)),
+            Action::Delay(Duration::from_nanos(0)),
+            Action::Delay(Duration::from_nanos(0)),
+        ],
+    )
+}


### PR DESCRIPTION
When a key sequence started by matching an any-key was timed out, the default key to emit was the pseudo key: `ANY_MACTH_KEY`, but that makes no sense, because the purpose of the timeout-key is to be invariant on timeout.

Instead the key that matched the any-key is used as the default key to emit, when the remap times out.

Example:

```yml
keymap:
    - remap:
        shift-ANY:
        timeout_millis: 200
        remap:
            A: B
```
Typing `KEY_K` emits `KEY_K` after `100ms` with no events.