### PR TITLE
Reconnect the COSMIC client when the cosmic-comp IPC drops

### DIFF
--- a/src/client/cosmic_client.rs
+++ b/src/client/cosmic_client.rs
@@ -83,8 +83,36 @@ impl CosmicClient {
     }
 
     fn borrow<'a>(&'a mut self) -> Result<(&'a mut EventQueue<State>, &'a mut State)> {
-        if self.queue.is_none() {
-            self.connect()?;
+        // cosmic-comp's Wayland IPC drops periodically (surfaces as a "Broken pipe").
+        // The original code only (re)connected when self.queue was None, but a dropped
+        // connection leaves self.queue as Some — so every later roundtrip() hit the dead
+        // socket and failed forever, silently disabling app-id matching until xremap was
+        // restarted by hand. Reconnect once on a roundtrip error so we self-heal.
+        for attempt in 0..2 {
+            if self.queue.is_none() {
+                self.connect()?;
+            }
+
+            let queue = self
+                .queue
+                .as_mut()
+                .ok_or_else(|| anyhow::format_err!("This cannot happen"))?;
+            let state = self
+                .state
+                .as_mut()
+                .ok_or_else(|| anyhow::format_err!("This cannot happen"))?;
+
+            match queue.roundtrip(state) {
+                Ok(_) => break,
+                Err(e) => {
+                    // Tear down the dead connection so the next iteration reconnects.
+                    self.queue = None;
+                    self.state = None;
+                    if attempt == 1 {
+                        return Err(e).context("cosmic IPC roundtrip failed after reconnect");
+                    }
+                }
+            }
         }
 
         let queue = self
@@ -95,8 +123,6 @@ impl CosmicClient {
             .state
             .as_mut()
             .ok_or_else(|| anyhow::format_err!("This cannot happen"))?;
-
-        queue.roundtrip(state)?;
 
         Ok((queue, state))
     }


### PR DESCRIPTION
`CosmicClient::borrow()` only (re)connects when `self.queue` is `None`. On COSMIC, cosmic-comp closes its Wayland IPC periodically (surfaces as `Io error: Broken pipe`). When that happens on a *live* connection, `self.queue` stays `Some`, so every later `queue.roundtrip(state)?` hits the dead socket and returns an error **forever**:

```
Error when fetching app_id: Backend error: Io error: Broken pipe (os error 32)
```

`current_application()` / `current_window()` then return `None` on every keypress, so all `application`/`window`-conditioned remaps silently stop firing until xremap is restarted by hand. The process stays "active", so `Restart=on-failure` never triggers.

**Fix:** in `borrow()`, on a `roundtrip()` error, tear down the dead `queue`/`state` and retry once — the retry re-runs `connect()`. A transient drop is healed on the same lookup; a genuinely-down compositor still returns an error after the single retry, so behavior on a hard failure is unchanged.

**Repro on COSMIC:** run the `cosmic` build with any `application`/`window` keymap, leave it running until cosmic-comp recycles the IPC (or restart cosmic-comp), then observe the remaps stay dead and the journal fills with the Broken-pipe line above. With this change, the next keypress reconnects and remapping resumes.

Cut against `v0.15.6`; `src/client/cosmic_client.rs` is byte-identical on `main`, so it applies cleanly there.
