### PR TITLE
Log `launch` commands when RUST_LOG=debug

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -682,7 +682,10 @@ impl EventHandler {
                     }
                 }
             }
-            KeymapAction::Launch(command) => self.run_command(command.clone()),
+            KeymapAction::Launch(command) => {
+                debug!("Launching command: {command:?}");
+                self.run_command(command.clone());
+            }
             KeymapAction::SetMode(mode) => {
                 self.mode = mode.clone();
                 println!("mode: {mode}");


### PR DESCRIPTION
When a `launch` action appears not to work, it can be difficult to tell which layer failed (an incorrect config.yml, a non-existent command, etc.).

Example:

```
[2026-07-27T06:48:56Z DEBUG xremap::event_handler] => 1: KEY_CAPSLOCK
[2026-07-27T06:48:56Z DEBUG xremap::event_handler] => 1: KEY_Z
[2026-07-27T06:48:56Z DEBUG xremap::event_handler] Launching command: ["notify-send", "Hello from xremap"]
```