### PR TITLE
Fix a race condition in device tests

### DIFF
--- a/tests/device.rs
+++ b/tests/device.rs
@@ -25,27 +25,6 @@ pub fn test_no_input_device_match() {
 }
 
 #[test]
-pub fn test_device_without_keys_is_not_selected_automatically() -> Result<()> {
-    // Create device without any output events.
-    let name = get_random_device_name();
-    let _device = VirtualDevice::builder()?.name(&name).build()?;
-    let _ = wait_for_device(&name)?;
-
-    // Automatically select devices
-    let devices = select_input_devices(&[], &vec![], false, false, "own_device")?;
-
-    assert_eq!(
-        0,
-        devices
-            .iter()
-            .filter(|(_, device)| device.device_name() == name)
-            .count()
-    );
-
-    Ok(())
-}
-
-#[test]
 pub fn test_device_filter_overwrites_keyboard_and_mouse_check() -> Result<()> {
     // Create device, that will not be selected automatically.
     let name = get_random_device_name();

--- a/tests/device_2.rs
+++ b/tests/device_2.rs
@@ -1,0 +1,31 @@
+#![cfg(feature = "device-test")]
+
+use crate::common::{get_random_device_name, wait_for_device};
+use anyhow::Result;
+use evdev::uinput::VirtualDevice;
+use xremap::private::select_input_devices;
+
+mod common;
+
+// Keep this test in its own integration-test binary because it grabs all
+// keyboards (see https://github.com/xremap/xremap/pull/967).
+#[test]
+pub fn test_device_without_keys_is_not_selected_automatically() -> Result<()> {
+    // Create a device without any output events.
+    let name = get_random_device_name();
+    let _device = VirtualDevice::builder()?.name(&name).build()?;
+    let _ = wait_for_device(&name)?;
+
+    // Automatically select devices
+    let devices = select_input_devices(&[], &vec![], false, false, "own_device")?;
+
+    assert_eq!(
+        0,
+        devices
+            .iter()
+            .filter(|(_, device)| device.device_name() == name)
+            .count()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fix a race condition in device tests

When running `cargo test --features device-test --test device` (with 14 threads
on my system), `test_last_device_removed_in_non_watch_mode` and
`test_wait_for_all_up_keys_up` sometimes fail:

test_wait_for_all_up_keys_up:

    stderr:
    Error: Device or resource busy (os error 16). Another program might have grabbed the device: 'test device eSubxmQCA6'

test_last_device_removed_in_non_watch_mode:

    stderr:
    Error: Device or resource busy (os error 16). Another program might have grabbed the device: 'test device dDCKpp5Suc'
    Error: Failed to prepare input devices: No device was selected!

This happens because `test_device_without_keys_is_not_selected_automatically`
performs automatic device selection and can grab virtual keyboards created by
other tests running in parallel.

Move the test back to `tests/device_2.rs`, which was removed in
https://github.com/xremap/xremap/pull/899/changes/681226b1d207c1425d9bc89ad948b5c54afed03a
(squashed as 4759ace1d9309d355ca0d1e9ab7e1e70ea1d9714), so Cargo runs it separately.