### PR TITLE
Fix fragile test: e2e_config_watch_is_debounced

### DIFF
--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -3,6 +3,7 @@
 use crate::common::{assert_events, containsn, key_press, key_release, xremap_controller::XremapController};
 use evdev::KeyCode;
 use indoc::indoc;
+use std::time::Instant;
 mod common;
 
 #[test]
@@ -95,6 +96,8 @@ pub fn e2e_config_watch_is_debounced() -> anyhow::Result<()> {
         .watch_config("config_watch_debounce_ms: 10")?
         .build()?;
 
+    let start_write = Instant::now();
+
     std::fs::write(&ctrl.get_config_file(), "")?;
     std::fs::write(&ctrl.get_config_file(), "partial_config")?;
     std::fs::write(&ctrl.get_config_file(), "")?;
@@ -107,6 +110,9 @@ pub fn e2e_config_watch_is_debounced() -> anyhow::Result<()> {
               f12: key_1
         "},
     )?;
+
+    let write_duration = Instant::now().duration_since(start_write);
+    println!("write duration: {:?}", write_duration);
 
     std::thread::sleep(std::time::Duration::from_millis(20));
 
@@ -122,7 +128,12 @@ pub fn e2e_config_watch_is_debounced() -> anyhow::Result<()> {
 
     let stdout = ctrl.kill_for_output()?.stdout;
 
-    assert!(containsn(1, &stdout, "Reloading Config"));
+    // Github tests have been observed to take around 100ms to complete
+    // write IO for this test case. But this test only makes sense
+    // if the writes are faster than the debounce value.
+    if write_duration < std::time::Duration::from_millis(10) {
+        assert!(containsn(1, &stdout, "Reloading Config"));
+    }
 
     Ok(())
 }


### PR DESCRIPTION
The test case `e2e_config_watch_is_debounced` has started failing in github tests. It's not at new problem, `v0.15.9` also fails at times. The observed problem is, that writes performed by the test can take too much time. Especially if the test case run concurrently with build jobs, which presumable make the IO congest.

The test now detects if writes are fast enough, so there's higher chance they'll reach xremap-under-test, which is the real timings that matter. But the test can't know it for certain.