### PR TITLE
Reload xremap action

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,12 @@ keymap:
 
 Pressing right `Ctrl` and `C` remaps to `End`. This leaves the normal remapping of `Ctrl-C` using left `Ctrl` to copy text.
 
-#### Reload config file with key combo
+#### Reload xremap with a key combo
 
 ```yml
 keymap:
   - remap:
-      f9: { action: reload_config }
+      f9: { action: reload }
 ```
 
 [List of all actions](doc/reference_actions.md).

--- a/doc/reference_actions.md
+++ b/doc/reference_actions.md
@@ -7,12 +7,17 @@ Actions can only be used in `keymap` and [press/release keys](reference_press_re
 | Name              | Description                                   | Added in |
 | ----------------- | --------------------------------------------- | -------- |
 | exit              | Close xremap gracefully                       | v0.15.10 |
+| reload            | Reload xremap                                 | v0.15.11 |
 | reload_config     | Reload configuration file, partially          | v0.15.10 |
 | pop_window_info   | Show popup with window-info used for matching | v0.15.10 |
 | print_window_info | Print window-info used for matching           | v0.15.10 |
 | print_window_list | Print list of open windows                    | v0.15.10 |
 
 The above actions are used like this: `TriggerKey: { action: name }`. Name is case-insensitive.
+
+Using `{ action: reload }` reloads the main xremap process. But only if the configuration file is free from errors.
+For users with a system service setup, it means only that process will reload itself.
+The bridge or GNOME extension isn't affected.
 
 `reload_config` reloads the same way `--watch` does. It's a limited reload, because
 reloading configuration in a running program is a hard thing to do. So it does a simple replacement

--- a/src/action.rs
+++ b/src/action.rs
@@ -22,6 +22,8 @@ pub enum Action {
     CloseByAppClass(String),
     // Close program gracefully
     Exit,
+    // Reload xremap
+    Reload,
     // Reload configuration file, partially.
     ReloadConfig,
     // Show popup with window-info used for matching

--- a/src/action_dispatcher.rs
+++ b/src/action_dispatcher.rs
@@ -35,6 +35,9 @@ impl ActionDispatcher {
             Action::Exit => {
                 return Ok(Some(MainAction::Exit));
             }
+            Action::Reload => {
+                return Ok(Some(MainAction::Reload { full: true }));
+            }
             Action::ReloadConfig => {
                 return Ok(Some(MainAction::Reload { full: false }));
             }
@@ -62,6 +65,7 @@ impl ActionDispatcher {
             | Action::Command(_)
             | Action::Delay(_)
             | Action::Exit
+            | Action::Reload
             | Action::ReloadConfig => {
                 unreachable!();
             }

--- a/src/action_dispatcher.rs
+++ b/src/action_dispatcher.rs
@@ -36,7 +36,7 @@ impl ActionDispatcher {
                 return Ok(Some(MainAction::Exit));
             }
             Action::ReloadConfig => {
-                return Ok(Some(MainAction::ReloadConfig));
+                return Ok(Some(MainAction::Reload { full: false }));
             }
             _ => {
                 self.handle_non_fatal_action(action, mainctrl)

--- a/src/config/keymap_action_without_args.rs
+++ b/src/config/keymap_action_without_args.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Deserializer};
 #[derive(Clone, Debug)]
 pub enum ActionWithoutArgs {
     Exit,
+    Reload,
     ReloadConfig,
     PopWindowInfo,
     PrintWindowInfo,
@@ -15,6 +16,8 @@ impl<'de> Deserialize<'de> for ActionWithoutArgs {
 
         if action == "exit" {
             Ok(ActionWithoutArgs::Exit)
+        } else if action == "reload" {
+            Ok(ActionWithoutArgs::Reload)
         } else if action == "reload_config" {
             Ok(ActionWithoutArgs::ReloadConfig)
         } else if action == "pop_window_info" {
@@ -45,7 +48,7 @@ mod tests {
                             - A
                     "
             },
-            "Actions after exit or reload_config are not allowed.",
+            "Actions after exit or reload are not allowed.",
         )
     }
 
@@ -56,11 +59,26 @@ mod tests {
                     keymap:
                       - remap:
                           f12:
+                            - { action: reload }
+                            - A
+                    "
+            },
+            "Actions after exit or reload are not allowed.",
+        )
+    }
+
+    #[test]
+    fn test_action_after_full_reload_fails() {
+        assert_invalid_config(
+            indoc! {"
+                    keymap:
+                      - remap:
+                          f12:
                             - { action: reload_config }
                             - A
                     "
             },
-            "Actions after exit or reload_config are not allowed.",
+            "Actions after exit or reload are not allowed.",
         )
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -102,12 +102,12 @@ fn check_specific_actions(actions: &Vec<KeymapAction>) -> anyhow::Result<()> {
     let mut actions_allowed = true;
     for action in actions {
         if !actions_allowed {
-            bail!("Actions after exit or reload_config are not allowed.")
+            bail!("Actions after exit or reload are not allowed.")
         }
 
         if let KeymapAction::Action(inner_action) = action {
             match inner_action {
-                ActionWithoutArgs::Exit | ActionWithoutArgs::ReloadConfig => {
+                ActionWithoutArgs::Exit | ActionWithoutArgs::Reload | ActionWithoutArgs::ReloadConfig => {
                     actions_allowed = false;
                 }
                 _ => {}

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -708,6 +708,9 @@ impl EventHandler {
                 ActionWithoutArgs::Exit => {
                     self.send_action(Action::Exit);
                 }
+                ActionWithoutArgs::Reload => {
+                    self.send_action(Action::Reload);
+                }
                 ActionWithoutArgs::ReloadConfig => {
                     self.send_action(Action::ReloadConfig);
                 }

--- a/src/main_impl.rs
+++ b/src/main_impl.rs
@@ -199,52 +199,53 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
         ),
     };
 
-    let timeout_manager = Rc::new(TimeoutManager::new());
+    'main_loop: loop {
+        let timeout_manager = Rc::new(TimeoutManager::new());
 
-    let mut input_devices = select_input_devices(&device_filter, &ignore_filter, mouse, watch_devices, &own_device)?;
+        let mut input_devices =
+            select_input_devices(&device_filter, &ignore_filter, mouse, watch_devices, &own_device)?;
 
-    // Watchers
-    let device_watcher = DeviceWatcher::new(watch_devices).context("Setting up device watcher")?;
-    let mut config_watcher = ConfigWatcher::new(watch_config, config_paths.clone(), config.config_watch_debounce_ms)?;
+        // Watchers
+        let device_watcher = DeviceWatcher::new(watch_devices).context("Setting up device watcher")?;
+        let mut config_watcher =
+            ConfigWatcher::new(watch_config, config_paths.clone(), config.config_watch_debounce_ms)?;
 
-    // Default allow launch (Change to false in a major upgrade)
-    let mut mainctrl = MainController::new(!no_window_logging, allow_launch.unwrap_or(true));
+        // Default allow launch (Change to false in a major upgrade)
+        let mut mainctrl = MainController::new(!no_window_logging, allow_launch.unwrap_or(true));
 
-    // OperatorHandler
-    let operator_handler = if config.experimental_map.len() > 0 {
-        Some(OperatorHandler::new(&config.experimental_map, timeout_manager.clone()))
-    } else {
-        None
-    };
+        // OperatorHandler
+        let operator_handler = if config.experimental_map.len() > 0 {
+            Some(OperatorHandler::new(&config.experimental_map, timeout_manager.clone()))
+        } else {
+            None
+        };
 
-    // EventHandler
-    let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
-    let delay = Duration::from_millis(config.keypress_delay_ms);
-    let mut handler = EventHandler::new(timer, &config.default_mode, delay, operator_handler);
+        // EventHandler
+        let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
+        let delay = Duration::from_millis(config.keypress_delay_ms);
+        let mut handler = EventHandler::new(timer, &config.default_mode, delay, operator_handler);
 
-    let output_device = output_device(
-        input_devices.values().next().map(InputDevice::bus_type),
-        config.enable_wheel,
-        vendor,
-        product,
-        &own_device,
-    )
-    .context("Failed to prepare an output device")?;
+        let output_device = output_device(
+            input_devices.values().next().map(InputDevice::bus_type),
+            config.enable_wheel,
+            vendor,
+            product,
+            &own_device,
+        )
+        .context("Failed to prepare an output device")?;
 
-    let throttle_emit = if config.throttle_ms == 0 {
-        None
-    } else {
-        Some(ThrottleEmit::new(Duration::from_millis(config.throttle_ms)))
-    };
+        let throttle_emit = if config.throttle_ms == 0 {
+            None
+        } else {
+            Some(ThrottleEmit::new(Duration::from_millis(config.throttle_ms)))
+        };
 
-    let mut dispatcher = ActionDispatcher::new(output_device, throttle_emit);
+        let mut dispatcher = ActionDispatcher::new(output_device, throttle_emit);
 
-    if config.notifications {
-        mainctrl.show_popup("Ready", None);
-    }
+        if config.notifications {
+            mainctrl.show_popup("Ready", None);
+        }
 
-    // Main loop
-    loop {
         'event_loop: loop {
             let main_action = event_loop(
                 &mut input_devices,
@@ -253,7 +254,7 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
                 &timeout_manager,
                 &mut handler,
                 &mut dispatcher,
-                &mut config,
+                &config,
                 &mut mainctrl,
                 &device_filter,
                 &ignore_filter,
@@ -273,7 +274,7 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
                             mainctrl.show_popup("Ready", None);
                         }
                         if full {
-                            unreachable!();
+                            continue 'main_loop;
                         } else {
                             // The new config is only partially used.
                             println!("Config Reloaded");
@@ -313,7 +314,7 @@ fn event_loop(
     timeout_manager: &Rc<TimeoutManager>,
     handler: &mut EventHandler,
     dispatcher: &mut ActionDispatcher,
-    config: &mut Config,
+    config: &Config,
     mainctrl: &mut MainController,
     device_filter: &[String],
     ignore_filter: &[String],

--- a/src/main_impl.rs
+++ b/src/main_impl.rs
@@ -242,51 +242,56 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
 
     // Main loop
     loop {
-        let main_action = event_loop(
-            &mut input_devices,
-            &device_watcher,
-            &mut config_watcher,
-            &timeout_manager,
-            &mut handler,
-            &mut dispatcher,
-            &mut config,
-            &mut mainctrl,
-            &device_filter,
-            &ignore_filter,
-            mouse,
-            &own_device,
-            &mut plugin,
-        )?;
+        'event_loop: loop {
+            let main_action = event_loop(
+                &mut input_devices,
+                &device_watcher,
+                &mut config_watcher,
+                &timeout_manager,
+                &mut handler,
+                &mut dispatcher,
+                &mut config,
+                &mut mainctrl,
+                &device_filter,
+                &ignore_filter,
+                mouse,
+                &own_device,
+                &mut plugin,
+            )?;
 
-        match main_action {
-            MainAction::Exit => {
-                return Ok(());
-            }
-            MainAction::ReloadConfig => match load_configs(&config_paths) {
-                Ok(new_config) => {
-                    println!("Reloading Config");
-                    // The new config is only partially used.
-                    config = new_config;
-                    if config.notifications {
-                        mainctrl.show_popup("Ready", None);
-                    }
+            match main_action {
+                MainAction::Exit => {
+                    return Ok(());
                 }
-                Err(err) => {
-                    if config.notifications {
-                        mainctrl.show_popup("Config error", Some(&err.to_string()));
+                MainAction::ReloadConfig => match load_configs(&config_paths) {
+                    Ok(new_config) => {
+                        println!("Reloading Config");
+                        // The new config is only partially used.
+                        config = new_config;
+                        if config.notifications {
+                            mainctrl.show_popup("Ready", None);
+                        }
+                        continue 'event_loop;
                     }
-                }
-            },
-            MainAction::RemoveDevice(device_info) => {
-                println!("Found a removed device: {:?}", device_info.name);
-                input_devices.retain(|path, _| device_info.path != *path);
+                    Err(err) => {
+                        if config.notifications {
+                            mainctrl.show_popup("Config error", Some(&err.to_string()));
+                        }
+                        continue 'event_loop;
+                    }
+                },
+                MainAction::RemoveDevice(device_info) => {
+                    println!("Found a removed device: {:?}", device_info.name);
+                    input_devices.retain(|path, _| device_info.path != *path);
 
-                if input_devices.is_empty() {
-                    if watch_devices {
-                        println!("No device was selected, but --watch is waiting for new devices.");
-                    } else {
-                        bail!("Last device was removed, and not watching for new devices");
+                    if input_devices.is_empty() {
+                        if watch_devices {
+                            println!("No device was selected, but --watch is waiting for new devices.");
+                        } else {
+                            bail!("Last device was removed, and not watching for new devices");
+                        }
                     }
+                    continue 'event_loop;
                 }
             }
         }

--- a/src/main_impl.rs
+++ b/src/main_impl.rs
@@ -284,6 +284,7 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
                         if config.notifications {
                             mainctrl.show_popup("Config error", Some(&err.to_string()));
                         }
+                        println!("Config error: {}", err.to_string());
                         continue 'event_loop;
                     }
                 },

--- a/src/main_impl.rs
+++ b/src/main_impl.rs
@@ -263,10 +263,10 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
                 return Ok(());
             }
             MainAction::ReloadConfig => match load_configs(&config_paths) {
-                Ok(c) => {
+                Ok(new_config) => {
                     println!("Reloading Config");
                     // The new config is only partially used.
-                    config = c;
+                    config = new_config;
                     if config.notifications {
                         mainctrl.show_popup("Ready", None);
                     }

--- a/src/main_impl.rs
+++ b/src/main_impl.rs
@@ -120,7 +120,7 @@ enum WatchTargets {
 #[derive(Debug)]
 pub enum MainAction {
     Exit,
-    ReloadConfig,
+    Reload { full: bool },
     RemoveDevice(Rc<InputDeviceInfo>),
 }
 
@@ -263,15 +263,19 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
                 MainAction::Exit => {
                     return Ok(());
                 }
-                MainAction::ReloadConfig => match load_configs(&config_paths) {
+                MainAction::Reload { full } => match load_configs(&config_paths) {
                     Ok(new_config) => {
-                        println!("Reloading Config");
-                        // The new config is only partially used.
                         config = new_config;
                         if config.notifications {
                             mainctrl.show_popup("Ready", None);
                         }
-                        continue 'event_loop;
+                        if full {
+                            unreachable!();
+                        } else {
+                            // The new config is only partially used.
+                            println!("Config Reloaded");
+                            continue 'event_loop;
+                        }
                     }
                     Err(err) => {
                         if config.notifications {

--- a/src/main_impl.rs
+++ b/src/main_impl.rs
@@ -176,8 +176,17 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
         return crate::bridge::main(!no_window_logging, allow_launch.unwrap_or(false));
     }
 
+    let watch_devices = watch.contains(&WatchTargets::Device);
+    let watch_config = watch.contains(&WatchTargets::Config);
+
+    let vendor = u16::from_str_radix(vendor.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x1234);
+    let product = u16::from_str_radix(product.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x5678);
+
+    // Device name
+    let own_device = output_device_name.unwrap_or_else(choose_device_name);
+
     // Configuration
-    let mut config = match crate::config::load_configs(&config_paths) {
+    let mut config = match load_configs(&config_paths) {
         Ok(config) => config,
         Err(e) => bail!(
             "Failed to load config '{}': {}",
@@ -189,22 +198,15 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
             e
         ),
     };
-    let watch_devices = watch.contains(&WatchTargets::Device);
-    let watch_config = watch.contains(&WatchTargets::Config);
 
     let timeout_manager = Rc::new(TimeoutManager::new());
 
-    // Device name
-    let own_device: String = output_device_name.unwrap_or_else(choose_device_name);
-
-    // Event listeners
-    let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
-    let delay = Duration::from_millis(config.keypress_delay_ms);
     let mut input_devices = select_input_devices(&device_filter, &ignore_filter, mouse, watch_devices, &own_device)?;
+
+    // Watchers
     let device_watcher = DeviceWatcher::new(watch_devices).context("Setting up device watcher")?;
     let mut config_watcher = ConfigWatcher::new(watch_config, config_paths.clone(), config.config_watch_debounce_ms)?;
 
-    // wmclient
     // Default allow launch (Change to false in a major upgrade)
     let mut mainctrl = MainController::new(!no_window_logging, allow_launch.unwrap_or(true));
 
@@ -216,9 +218,10 @@ pub fn xremap_cli(mut plugin: impl Plugin) -> anyhow::Result<()> {
     };
 
     // EventHandler
+    let timer = TimerFd::new(ClockId::CLOCK_MONOTONIC, TimerFlags::empty())?;
+    let delay = Duration::from_millis(config.keypress_delay_ms);
     let mut handler = EventHandler::new(timer, &config.default_mode, delay, operator_handler);
-    let vendor = u16::from_str_radix(vendor.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x1234);
-    let product = u16::from_str_radix(product.unwrap_or_default().trim_start_matches("0x"), 16).unwrap_or(0x5678);
+
     let output_device = output_device(
         input_devices.values().next().map(InputDevice::bus_type),
         config.enable_wheel,

--- a/src/platform_linux/config_watcher.rs
+++ b/src/platform_linux/config_watcher.rs
@@ -60,7 +60,7 @@ impl ConfigWatcher {
         if readable_fds.contains(&self.timer.as_fd().as_raw_fd()) {
             self.change_pending = false;
             self.timer.unset()?;
-            return Ok(Some(MainAction::ReloadConfig));
+            return Ok(Some(MainAction::Reload { full: false }));
         }
 
         if let Ok(events) = self.inotify.read_events() {
@@ -73,7 +73,7 @@ impl ConfigWatcher {
                             .set(Expiration::OneShot(TimeSpec::from_duration(debounce)), TimerSetTimeFlags::empty())?;
                     }
                     None => {
-                        return Ok(Some(MainAction::ReloadConfig));
+                        return Ok(Some(MainAction::Reload { full: false }));
                     }
                 };
             }

--- a/src/throttle_emit.rs
+++ b/src/throttle_emit.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 pub struct ThrottleEmit {
     delay: Duration,
-    // When modifier was last either pressed or released.
+    // When any modifier was last either pressed or released.
     last_mod: Instant,
     // When any ordinary key was last pressed.
     last_key_press: Instant,

--- a/tests/common/xremap_controller.rs
+++ b/tests/common/xremap_controller.rs
@@ -4,6 +4,7 @@ use crate::common::{
 };
 use anyhow::{bail, Result};
 use evdev::{Device, EventType, FetchEventsSynced, InputEvent, KeyCode as Key};
+use nix::libc::ENODEV;
 use std::cell::Cell;
 use std::iter::repeat_with;
 use std::path::PathBuf;
@@ -294,6 +295,26 @@ impl XremapController {
         self.output_device = Some(device);
 
         Ok(())
+    }
+
+    pub fn forget_output_device(&mut self) -> anyhow::Result<()> {
+        match &mut self.output_device {
+            Some(device) => {
+                device.ungrab().or_else(|err| {
+                    if err.raw_os_error() == Some(ENODEV) {
+                        // Suppress when device is already gone.
+                        Ok(())
+                    } else {
+                        Err(err)
+                    }
+                })?;
+                self.output_device = None;
+                Ok(())
+            }
+            None => {
+                bail!("No output device to forget.")
+            }
+        }
     }
 
     pub fn emit_events(&mut self, events: &[InputEvent]) -> anyhow::Result<()> {

--- a/tests/main_actions.rs
+++ b/tests/main_actions.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "device-test")]
 
 use crate::common::xremap_controller::XremapController;
-use crate::common::{assert_events, key_press, key_release};
+use crate::common::{assert_events, containsn, key_press, key_release};
 use evdev::KeyCode;
 use indoc::indoc;
 use std::thread;
@@ -70,6 +70,87 @@ pub fn e2e_actions_before_exit_action() -> anyhow::Result<()> {
     ctrl.wait_for_output()?;
 
     Ok(())
+}
+
+#[test]
+pub fn e2e_full_reload_recreates_output_device() -> anyhow::Result<()> {
+    let mut ctrl = XremapController::builder()
+        .config(indoc! {"
+              keymap:
+                - remap:
+                    f12: { action: reload }
+            "})?
+        .build()?;
+
+    ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12)])?;
+
+    ctrl.fetch_until_end()?; // Will timeout if device isn't closed.
+
+    ctrl.kill()
+}
+
+#[test]
+pub fn e2e_full_reload_cancels_at_config_error() -> anyhow::Result<()> {
+    let mut ctrl = XremapController::builder()
+        .allow_stdio_errors(true)
+        .config(indoc! {"
+              keymap:
+                - remap:
+                    f11: KEY_A
+                    f12: { action: reload }
+            "})?
+        .build()?;
+
+    std::fs::write(&ctrl.get_config_file(), "partial_config")?;
+
+    ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12)])?;
+
+    // Old config is still in effect.
+    ctrl.emit_events(&vec![key_press(KeyCode::KEY_F11), key_release(KeyCode::KEY_F11)])?;
+
+    assert_events(
+        ctrl.fetch_until_key(KeyCode::KEY_A)?,
+        indoc! {"
+            a:1
+            a:0
+        "},
+    );
+
+    let stdout = ctrl.kill_for_output()?.stdout;
+    assert!(containsn(1, &stdout, "Config error"));
+
+    Ok(())
+}
+
+#[test]
+pub fn e2e_full_reload_cancels_timers() -> anyhow::Result<()> {
+    let mut ctrl = XremapController::builder()
+        .config(indoc! {"
+              experimental_map:
+                - remap:
+                    f11: { double: A }
+              keymap:
+                - remap:
+                    f12: { action: reload }
+            "})?
+        .build()?;
+
+    // These keys are buffered, and will be forgot because of reload.
+    ctrl.emit_events(&vec![key_press(KeyCode::KEY_F11), key_release(KeyCode::KEY_F11)])?;
+
+    // Reload
+    ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12), key_release(KeyCode::KEY_F12)])?;
+    ctrl.fetch_until_end()?; // Will timeout if device isn't closed.
+
+    // Reopen device
+    ctrl.forget_output_device()?;
+    ctrl.open_output_device()?;
+
+    // DoubleTapOperator will buffer KEY_MOVE sent by `fetch()`, so it's guaranteed
+    //  that it has made a decision when KEY_MOVE is received here.
+    assert_events(ctrl.fetch()?, "");
+
+    ctrl.kill()
 }
 
 #[test]

--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -31,7 +31,7 @@ pub fn e2e_watch_config() -> anyhow::Result<()> {
         "},
     );
 
-    assert!(ctrl.kill_for_output()?.stdout.contains("Reloading Config"));
+    assert!(ctrl.kill_for_output()?.stdout.contains("Config Reloaded"));
 
     Ok(())
 }
@@ -132,7 +132,7 @@ pub fn e2e_config_watch_is_debounced() -> anyhow::Result<()> {
     // write IO for this test case. But this test only makes sense
     // if the writes are faster than the debounce value.
     if write_duration < std::time::Duration::from_millis(10) {
-        assert!(containsn(1, &stdout, "Reloading Config"));
+        assert!(containsn(1, &stdout, "Config Reloaded"));
     }
 
     Ok(())
@@ -162,7 +162,7 @@ pub fn e2e_config_watch_with_notifications() -> anyhow::Result<()> {
 
     assert!(containsn(2, &stdout, r#"["notify-send", "-a", "xremap", "Ready"]"#));
     assert!(containsn(1, &stdout, r#"["notify-send", "-a", "xremap", "Config error""#));
-    assert!(containsn(1, &stdout, "Reloading Config"));
+    assert!(containsn(1, &stdout, "Config Reloaded"));
 
     Ok(())
 }

--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -53,8 +53,8 @@ pub fn e2e_old_config_remains_active_when_error() -> anyhow::Result<()> {
     std::thread::sleep(std::time::Duration::from_millis(20));
 
     // This is fragile without debounce, because the file write can cause
-    // two events one with an empty file and one with the new content.
-    // This means xremap drops the old and replace it with a 'blank' config,
+    // two events. One with an empty file and one with the new content.
+    // This means xremap drops the old and replaces it with a 'blank' config,
     // instead of leaving the old in place.
     ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12), key_release(KeyCode::KEY_F12)])?;
 

--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -39,6 +39,7 @@ pub fn e2e_watch_config() -> anyhow::Result<()> {
 #[test]
 pub fn e2e_old_config_remains_active_when_error() -> anyhow::Result<()> {
     let mut ctrl = XremapController::builder()
+        .allow_stdio_errors(true)
         .watch_config(indoc! {"
               config_watch_debounce_ms: 10
               keymap:


### PR DESCRIPTION
Adds an action, that restarts all of xremap:

```yml
keymap:
  - remap:
      f12: { action: reload }
```
The current action: `{ action: reload_config }` doesn't work fully, and it's much easier to reload full xremap, than finding a way to only reload the config, which is spread out in different structs in the xremap process.