### PR TITLE
Disable auto-merge of dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,26 +1,28 @@
-# from https://github.com/gofiber/swagger/blob/main/.github/workflows/dependabot_automerge.yml
-name: dependabot
-on:
-  pull_request_target:
+# To get dependabot PRs merge automatically uncomment below:
 
-jobs:
-  auto-merge:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: Dependabot metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
-        id: metadata
-      - name: Wait for status checks
-        uses: lewagon/wait-on-check-action@96d9100b431964d10e0136aff8b9ccb92470505e
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-regexp: '(build|test|fmt) \(.*\)'
-          wait-interval: 30
-      - name: Auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --rebase "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+# # from https://github.com/gofiber/swagger/blob/main/.github/workflows/dependabot_automerge.yml
+# name: dependabot
+# on:
+#   pull_request_target:
+
+# jobs:
+#   auto-merge:
+#     runs-on: ubuntu-latest
+#     if: ${{ github.actor == 'dependabot[bot]' }}
+#     steps:
+#       - name: Dependabot metadata
+#         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
+#         id: metadata
+#       - name: Wait for status checks
+#         uses: lewagon/wait-on-check-action@96d9100b431964d10e0136aff8b9ccb92470505e
+#         with:
+#           repo-token: ${{ secrets.GITHUB_TOKEN }}
+#           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+#           check-regexp: '(build|test|fmt) \(.*\)'
+#           wait-interval: 30
+#       - name: Auto-merge for Dependabot PRs
+#         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+#         run: gh pr merge --auto --rebase "$PR_URL"
+#         env:
+#           PR_URL: ${{github.event.pull_request.html_url}}
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There are two reasons for this:
- The fewer dependencies the better.
- I personally don't appreciate that things suddenly get merged. And prefer to have a chance to look through the changes.

This can always be enabled again, if so desired.