### PR TITLE
Remove lazy_static crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,12 +949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,7 +2040,6 @@ dependencies = [
  "hyprland",
  "indexmap 2.14.0",
  "indoc",
- "lazy_static",
  "log",
  "niri-ipc",
  "nix 0.31.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ evdev = "0.13.2"
 fork = "0.10"
 futures-util = {version = "0.3", optional = true}
 indoc = "2.0"
-lazy_static = "1.5.0"
 log = "0.4.31"
 nix = { version = "0.31", features = ["inotify", "poll", "time", "signal", "user"] }
 niri-ipc = { version = "25.11.0", optional = true }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -11,7 +11,6 @@ use crate::device::InputDeviceInfo;
 use crate::event::{Event, KeyEvent, RelativeEvent};
 use crate::operator_handler::OperatorHandler;
 use evdev::KeyCode as Key;
-use lazy_static::lazy_static;
 use log::{debug, warn};
 use nix::sys::time::TimeSpec;
 use nix::sys::timerfd::{Expiration, TimerFd, TimerSetTimeFlags};
@@ -829,22 +828,20 @@ fn contains_modifier(modifiers: &[Modifier], key: &Key) -> bool {
     false
 }
 
-lazy_static! {
-    pub static ref MODIFIER_KEYS: [Key; 8] = [
-        // Shift
-        Key::KEY_LEFTSHIFT,
-        Key::KEY_RIGHTSHIFT,
-        // Control
-        Key::KEY_LEFTCTRL,
-        Key::KEY_RIGHTCTRL,
-        // Alt
-        Key::KEY_LEFTALT,
-        Key::KEY_RIGHTALT,
-        // Windows
-        Key::KEY_LEFTMETA,
-        Key::KEY_RIGHTMETA,
-    ];
-}
+pub static MODIFIER_KEYS: [Key; 8] = [
+    // Shift
+    Key::KEY_LEFTSHIFT,
+    Key::KEY_RIGHTSHIFT,
+    // Control
+    Key::KEY_LEFTCTRL,
+    Key::KEY_RIGHTCTRL,
+    // Alt
+    Key::KEY_LEFTALT,
+    Key::KEY_RIGHTALT,
+    // Windows
+    Key::KEY_LEFTMETA,
+    Key::KEY_RIGHTMETA,
+];
 
 // ---
 


### PR DESCRIPTION
This crate is not needed to create `MODIFIER_KEYS` array longer.