### PR TITLE
Fix fragile test: e2e_config_watch_is_debounced

### DIFF
--- a/tests/common/xremap_controller.rs
+++ b/tests/common/xremap_controller.rs
@@ -119,7 +119,7 @@ pub struct XremapController {
     // Is None when xremap has been stopped.
     child: Cell<Option<Child>>,
     nocapture: bool,
-    allow_stdio_errors: bool,
+    pub allow_stdio_errors: bool,
     // Input from xremap's perspective
     input_device: Option<VirtualDeviceInfo>,
     // Output from xremap's perspective

--- a/tests/watch-config.rs
+++ b/tests/watch-config.rs
@@ -115,6 +115,15 @@ pub fn e2e_config_watch_is_debounced() -> anyhow::Result<()> {
     let write_duration = Instant::now().duration_since(start_write);
     println!("write duration: {:?}", write_duration);
 
+    if write_duration > std::time::Duration::from_millis(10) {
+        // Github tests have been observed to take around 100ms to complete
+        // write IO for this test case. But this test only makes sense
+        // if the writes are faster than the debounce value.
+        println!("Test cancelled. IO is too slow.");
+        ctrl.allow_stdio_errors = true; // Errors are not relevant.
+        return ctrl.kill();
+    }
+
     std::thread::sleep(std::time::Duration::from_millis(20));
 
     ctrl.emit_events(&vec![key_press(KeyCode::KEY_F12)])?;
@@ -129,12 +138,7 @@ pub fn e2e_config_watch_is_debounced() -> anyhow::Result<()> {
 
     let stdout = ctrl.kill_for_output()?.stdout;
 
-    // Github tests have been observed to take around 100ms to complete
-    // write IO for this test case. But this test only makes sense
-    // if the writes are faster than the debounce value.
-    if write_duration < std::time::Duration::from_millis(10) {
-        assert!(containsn(1, &stdout, "Config Reloaded"));
-    }
+    assert!(containsn(1, &stdout, "Config Reloaded"));
 
     Ok(())
 }


### PR DESCRIPTION
This test has been problematic before. [And now fails again](https://github.com/xremap/xremap/actions/runs/31961386286/job/95199788033)

So now it's completely disabled if IO is too slow