### PR TITLE
Add Throttle Operator

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -29,6 +29,7 @@ Each method has pros and cons, it's worth checking out the pages before choosing
 
 - [Double tap](reference_double_tap.md)
 - [Chords (simultaneous keys)](reference_chords.md)
+- [Throttle keys](reference_throttle.md)
 - [FreeBSD](reference_freebsd.md)
 - [Scripting](reference_scripting.md)
 

--- a/doc/reference_throttle.md
+++ b/doc/reference_throttle.md
@@ -1,0 +1,56 @@
+## Throttle a key
+
+`throttle_ms` controls how fast a key can be reused.
+
+Working since v0.15.12
+
+### Experimental
+
+Experimental means this feature is likely to change in the future as it's improved. This
+can break configuration files in any version update of xremap, and will be noted in CHANGELOG.md.
+
+Features available in `modmap` like: `device`, `mode`, key-to-key mapping,
+multi-purpose key and press/release key don't work in `experimental_map`.
+But application-specific remapping with `application` and `window` works since `v0.15.5`.
+
+### Description
+
+It works by letting the first event-cycle through. That is press-repeat-release are let through.
+Then are all events squashed until timeout is reached, where the key can again be used.
+
+Timeout may happen while the key is physically pressed, and in that case will repeat and release events
+still go through, so the key is consistently released.
+
+## Examples
+
+### Example: Protect angainst accidental double tap
+
+If you have a tendency to accidentally pressing a key twice, when the intention
+was to just press it once, it's possible to set a high timeout, so the key
+doesn't have any effect the second time.
+
+```yml
+experimental_map:
+  - remap:
+      kpminus: { throttle_ms: 2000 }
+```
+
+### Example: Prevent faulty keyboard events
+
+If a keyboard is faulty and outputs double tap, when it was actually just pressed once.
+It's possible to drop the extra events:
+
+```yml
+experimental_map:
+  - remap:
+      kpminus: { throttle_ms: 50 }
+```
+
+Note: This is only a partial solution to the problem, because altough double tap
+is prevented, the key is released again fast. So it looses its repeat-functionality.
+A better solution is a method like QMK, that throttles press and release-events together.
+
+## References
+
+- Definitions used: [throttle](https://rxjs.dev/api/operators/throttle), [debounce](https://rxjs.dev/api/operators/debounce)
+- QMK: [Contact bounce / contact chatter](https://docs.qmk.fm/feature_debounce_type)

--- a/src/config/deserializers.rs
+++ b/src/config/deserializers.rs
@@ -24,3 +24,6 @@ where
     let millis = u64::deserialize(deserializer)?;
     Ok(Duration::from_millis(millis))
 }
+
+#[derive(Deserialize, Debug)]
+pub struct DurationWrapper(#[serde(deserialize_with = "deserialize_duration")] pub Duration);

--- a/src/config/expmap_operator.rs
+++ b/src/config/expmap_operator.rs
@@ -1,4 +1,5 @@
-use crate::config::deserializers::deserialize_duration;
+use crate::config::deserialize_single_field;
+use crate::config::deserializers::{deserialize_duration, DurationWrapper};
 use crate::config::key::deserialize_key;
 use evdev::KeyCode as Key;
 use serde::{Deserialize, Deserializer};
@@ -9,6 +10,12 @@ use std::time::Duration;
 #[serde(untagged)]
 pub enum ExpmapOperator {
     DoubleTap(DoubleTap),
+    #[serde(deserialize_with = "deserialize_throttle")]
+    Throttle(Duration),
+}
+
+pub fn deserialize_throttle<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Duration, D::Error> {
+    Ok(deserialize_single_field::<D, DurationWrapper>(deserializer, "throttle_ms")?.0)
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -19,6 +19,10 @@ pub enum Event {
 }
 
 impl Event {
+    pub fn key_event2(device: Rc<InputDeviceInfo>, key_event: KeyEvent) -> Event {
+        Event::KeyEvent(device, key_event)
+    }
+
     #[cfg(test)]
     pub fn key_release(code: Key) -> Event {
         Event::KeyEvent(crate::tests::get_input_device_info(), KeyEvent::new(code, KeyValue::Release))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod main_impl;
 mod operator_double_tap;
 mod operator_handler;
 mod operator_sim;
+mod operator_throttle;
 mod operators;
 mod plugin;
 #[cfg(test)]
@@ -68,6 +69,8 @@ mod tests_operator_double_tap;
 mod tests_operator_handler;
 #[cfg(test)]
 mod tests_operator_sim;
+#[cfg(test)]
+mod tests_operator_throttle;
 #[cfg(test)]
 mod tests_throttle_emit;
 #[cfg(test)]

--- a/src/operator_double_tap.rs
+++ b/src/operator_double_tap.rs
@@ -41,13 +41,13 @@ impl StaticOperator for DoubleTapOperator {
         }
 
         match event {
-            Event::KeyEvent(device, key_event) => Box::new(ActiveDoubleTapOperator {
+            Event::KeyEvent(_, key_event) => Box::new(ActiveDoubleTapOperator {
                 key: key_event.key,
                 actions: self.actions.clone(),
                 timeout: self.timeout,
                 start_inst: Instant::now(),
                 buffered: vec![],
-                state: State::Pressed { device: device.clone() },
+                state: State::Pressed,
             }),
             _ => {
                 unreachable!()
@@ -58,13 +58,8 @@ impl StaticOperator for DoubleTapOperator {
 
 #[derive(Debug)]
 enum State {
-    Pressed {
-        device: Rc<InputDeviceInfo>,
-    },
-    Tapped {
-        press_device: Rc<InputDeviceInfo>,
-        release_device: Rc<InputDeviceInfo>,
-    },
+    Pressed,
+    Tapped,
     Emitted,
     Done,
 }
@@ -104,14 +99,11 @@ impl ActiveOperator for ActiveDoubleTapOperator {
 impl ActiveDoubleTapOperator {
     fn on_press(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
         match &mut self.state {
-            State::Pressed { device: _ } | State::Emitted if self.key == key_event.key => {
+            State::Pressed | State::Emitted if self.key == key_event.key => {
                 // Suppress spurious press
                 OperatorAction::Undecided
             }
-            State::Tapped {
-                press_device,
-                release_device,
-            } if self.key == key_event.key => {
+            State::Tapped if self.key == key_event.key => {
                 let emit = map_actions(&self.actions, device, KeyValue::Press);
 
                 // Flush buffered events.
@@ -123,11 +115,7 @@ impl ActiveDoubleTapOperator {
                 OperatorAction::Partial(emit, buffered)
             }
             // Buffer events when matching
-            State::Pressed { device: _ }
-            | State::Tapped {
-                press_device: _,
-                release_device: _,
-            } => {
+            State::Pressed | State::Tapped => {
                 self.buffered.push(Event::KeyEvent(device.clone(), key_event.clone()));
 
                 OperatorAction::Undecided
@@ -141,26 +129,16 @@ impl ActiveDoubleTapOperator {
 
     fn on_release(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
         match &self.state {
-            State::Pressed { device: press_device } if self.key == key_event.key => {
-                self.state = State::Tapped {
-                    press_device: press_device.clone(),
-                    release_device: device.clone(),
-                };
+            State::Pressed if self.key == key_event.key => {
+                self.state = State::Tapped;
 
                 OperatorAction::Undecided
             }
-            State::Tapped {
-                press_device,
-                release_device,
-            } if self.key == key_event.key => {
+            State::Tapped if self.key == key_event.key => {
                 // Suppress spurious release
                 OperatorAction::Undecided
             }
-            State::Tapped {
-                press_device: _,
-                release_device: _,
-            }
-            | State::Pressed { device: _ } => {
+            State::Tapped | State::Pressed => {
                 self.buffered.push(Event::KeyEvent(device.clone(), key_event.clone()));
 
                 OperatorAction::Undecided
@@ -180,11 +158,7 @@ impl ActiveDoubleTapOperator {
     fn on_repeat(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
         match &self.state {
             // Suppress repeat when matching
-            State::Pressed { device: _ }
-            | State::Tapped {
-                press_device: _,
-                release_device: _,
-            } => OperatorAction::Undecided,
+            State::Pressed | State::Tapped => OperatorAction::Undecided,
 
             // Repeat the emitted key.
             State::Emitted if self.key == key_event.key => {
@@ -201,11 +175,7 @@ impl ActiveDoubleTapOperator {
 
     fn on_tick(&mut self) -> OperatorAction {
         match &mut self.state {
-            State::Pressed { device: _ }
-            | State::Tapped {
-                press_device: _,
-                release_device: _,
-            } => {
+            State::Pressed | State::Tapped => {
                 if self.start_inst.elapsed() <= self.timeout {
                     OperatorAction::Undecided
                 } else {
@@ -227,11 +197,7 @@ impl ActiveDoubleTapOperator {
     fn on_other(&mut self, event: &Event) -> OperatorAction {
         match &mut self.state {
             // Suppress when matching
-            State::Pressed { device: _ }
-            | State::Tapped {
-                press_device: _,
-                release_device: _,
-            } => {
+            State::Pressed | State::Tapped => {
                 self.buffered.push(event.clone());
                 OperatorAction::Undecided
             }

--- a/src/operator_double_tap.rs
+++ b/src/operator_double_tap.rs
@@ -47,7 +47,7 @@ impl StaticOperator for DoubleTapOperator {
                 timeout: self.timeout,
                 start_inst: Instant::now(),
                 buffered: vec![],
-                state: State::Pressed,
+                state: State::New,
             }),
             _ => {
                 unreachable!()
@@ -58,6 +58,7 @@ impl StaticOperator for DoubleTapOperator {
 
 #[derive(Debug)]
 enum State {
+    New,
     Pressed,
     Tapped,
     Emitted,
@@ -99,6 +100,10 @@ impl ActiveOperator for ActiveDoubleTapOperator {
 impl ActiveDoubleTapOperator {
     fn on_press(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
         match &mut self.state {
+            State::New => {
+                self.state = State::Pressed;
+                OperatorAction::Undecided
+            }
             State::Pressed | State::Emitted if self.key == key_event.key => {
                 // Suppress spurious press
                 OperatorAction::Undecided
@@ -129,6 +134,7 @@ impl ActiveDoubleTapOperator {
 
     fn on_release(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
         match &self.state {
+            State::New => unreachable!(),
             State::Pressed if self.key == key_event.key => {
                 self.state = State::Tapped;
 
@@ -157,6 +163,7 @@ impl ActiveDoubleTapOperator {
 
     fn on_repeat(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
         match &self.state {
+            State::New => unreachable!(),
             // Suppress repeat when matching
             State::Pressed | State::Tapped => OperatorAction::Undecided,
 
@@ -175,6 +182,7 @@ impl ActiveDoubleTapOperator {
 
     fn on_tick(&mut self) -> OperatorAction {
         match &mut self.state {
+            State::New => unreachable!(),
             State::Pressed | State::Tapped => {
                 if self.start_inst.elapsed() <= self.timeout {
                     OperatorAction::Undecided
@@ -196,6 +204,7 @@ impl ActiveDoubleTapOperator {
 
     fn on_other(&mut self, event: &Event) -> OperatorAction {
         match &mut self.state {
+            State::New => unreachable!(),
             // Suppress when matching
             State::Pressed | State::Tapped => {
                 self.buffered.push(event.clone());

--- a/src/operator_handler.rs
+++ b/src/operator_handler.rs
@@ -6,6 +6,7 @@ use crate::event::Event;
 use crate::event_handler::PRESS;
 use crate::operator_double_tap::DoubleTapOperator;
 use crate::operator_sim::SimOperator;
+use crate::operator_throttle::ThrottleOperator;
 use crate::operators::{ActiveOperator, OperatorAction, OperatorEntry, StaticOperator};
 use crate::timeout_manager::TimeoutManager;
 use evdev::KeyCode as Key;
@@ -56,6 +57,7 @@ impl OperatorHandler {
                     ExpmapOperator::DoubleTap(dbltap) => {
                         DoubleTapOperator::get_ops(*key, dbltap, timeout_manager.clone())
                     }
+                    ExpmapOperator::Throttle(timeout) => ThrottleOperator::get_ops(*key, *timeout),
                 };
                 append(operators, &mut lookup_map, expmap);
             }

--- a/src/operator_handler.rs
+++ b/src/operator_handler.rs
@@ -147,6 +147,7 @@ struct Candidates {
 }
 
 // Nodes that exist on the stack, that still needs to be processed.
+#[derive(Debug)]
 enum Node {
     Event(Event),
     Operator(Box<dyn ActiveOperator>),
@@ -204,8 +205,11 @@ fn process_event(
                     // No more operators
                     None => {
                         match candidates {
-                            Some(candidates) => try_candidates(event, &mut left, candidates),
-                            None => static_lookup(event, candidates, &lookup_map, &mut emit, wmclient),
+                            Some(candidates) => {
+                                candidates.events.push(event.clone());
+                                try_candidates(event, &mut left, candidates)
+                            }
+                            None => static_lookup(event, &mut left, candidates, &lookup_map, &mut emit, wmclient),
                         };
                     }
                 };
@@ -232,7 +236,7 @@ fn process_event(
 
                 // start_key didn't match anything, so emit.
                 emit.push(Emit::Single(taken.start_event.clone()));
-                // Start over with the next event.
+                // Start over from the next event.
                 unhandled_back_to_stack(taken.events, &mut left);
             }
 
@@ -255,8 +259,6 @@ fn unhandled_back_to_stack(events: Vec<Event>, nodes: &mut Vec<Node>) {
 }
 
 fn try_candidates(event: Event, left: &mut Vec<Node>, candidates: &mut Candidates) {
-    candidates.events.push(event.clone());
-
     let mut first = true;
 
     for (usize, candidate) in candidates.operators.iter_mut().enumerate() {
@@ -325,6 +327,7 @@ fn try_candidates(event: Event, left: &mut Vec<Node>, candidates: &mut Candidate
 
 fn static_lookup(
     event: Event,
+    left: &mut Vec<Node>,
     candidates: &mut Option<Candidates>,
     lookup_map: &HashMap<Key, Vec<OperatorEntry>>,
     emit: &mut Vec<Emit>,
@@ -378,11 +381,13 @@ fn static_lookup(
                 })
                 .collect();
 
-            candidates.replace(Candidates {
-                start_event: event,
+            let candidates = candidates.insert(Candidates {
+                start_event: event.clone(),
                 events: vec![],
                 operators: new_candidates,
             });
+
+            try_candidates(event, left, candidates);
         }
         None => {
             emit.push(Emit::key_event(device.clone(), key_event.clone()));

--- a/src/operator_sim.rs
+++ b/src/operator_sim.rs
@@ -64,18 +64,14 @@ impl StaticOperator for SimOperator {
         }
 
         match event {
-            Event::KeyEvent(_, key_event) => {
-                let still_missing: Vec<_> = self.keys.iter().filter(|&&key| key != key_event.key).cloned().collect();
-
-                Box::new(ActiveSimOperator {
-                    keys: self.keys.clone(),
-                    actions: self.actions.clone(),
-                    start_inst: Instant::now(),
-                    buffered: vec![],
-                    state: State::Pressed { still_missing },
-                    timeout: self.timeout,
-                })
-            }
+            Event::KeyEvent(_, _) => Box::new(ActiveSimOperator {
+                keys: self.keys.clone(),
+                actions: self.actions.clone(),
+                start_inst: Instant::now(),
+                buffered: vec![],
+                state: State::New,
+                timeout: self.timeout,
+            }),
             _ => {
                 unreachable!()
             }
@@ -85,6 +81,7 @@ impl StaticOperator for SimOperator {
 
 #[derive(Debug)]
 enum State {
+    New,
     // Some trigger keys have been pressed.
     Pressed { still_missing: Vec<Key> },
     // The action has been pressed.
@@ -130,6 +127,12 @@ impl ActiveOperator for ActiveSimOperator {
 impl ActiveSimOperator {
     fn on_press(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
         match &mut self.state {
+            State::New => {
+                self.state = State::Pressed {
+                    still_missing: self.keys.iter().filter(|&&key| key != key_event.key).cloned().collect(),
+                };
+                OperatorAction::Undecided
+            }
             State::Pressed { still_missing } => {
                 if vec![key_event.key] == *still_missing {
                     // All keys pressed
@@ -179,6 +182,7 @@ impl ActiveSimOperator {
 
     fn on_release(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
         match &mut self.state {
+            State::New => unreachable!(),
             State::Pressed { still_missing } => {
                 if self.keys.contains(&key_event.key) && !still_missing.contains(&key_event.key) {
                     // A trigger key has been pressed and now released. So cancel.
@@ -236,6 +240,7 @@ impl ActiveSimOperator {
 
     fn on_repeat(&mut self, _: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
         match &self.state {
+            State::New => unreachable!(),
             // Suppress repeat when matching
             State::Pressed { still_missing: _ } => OperatorAction::Undecided,
             State::Emitted { device } => {
@@ -268,6 +273,7 @@ impl ActiveSimOperator {
 
     fn on_tick(&mut self) -> OperatorAction {
         match &self.state {
+            State::New => unreachable!(),
             State::Pressed { still_missing: _ } if self.start_inst.elapsed() <= self.timeout => {
                 OperatorAction::Undecided
             }
@@ -286,6 +292,7 @@ impl ActiveSimOperator {
 
     fn on_other(&mut self, event: &Event) -> OperatorAction {
         match &mut self.state {
+            State::New => unreachable!(),
             State::Pressed { still_missing: _ } => {
                 self.buffered.push(event.clone());
                 OperatorAction::Undecided

--- a/src/operator_throttle.rs
+++ b/src/operator_throttle.rs
@@ -1,0 +1,182 @@
+use crate::device::InputDeviceInfo;
+use crate::emit_handler::Emit;
+use crate::event::{Event, KeyEvent};
+use crate::operators::{ActiveOperator, OperatorAction, StaticOperator};
+use evdev::KeyCode as Key;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
+use std::vec;
+
+#[derive(Debug, Clone)]
+pub struct ThrottleOperator {
+    key: Key,
+    timeout: Duration,
+}
+
+impl ThrottleOperator {
+    pub fn get_ops(key: Key, timeout: Duration) -> Vec<(Key, Box<dyn StaticOperator>)> {
+        vec![(key, Box::new(ThrottleOperator { key, timeout }))]
+    }
+}
+
+impl StaticOperator for ThrottleOperator {
+    fn get_active_operator(&self, event: &Event) -> Box<dyn ActiveOperator> {
+        match event {
+            Event::KeyEvent(_, _) => Box::new(ActiveThrottleOperator {
+                key: self.key,
+                timeout: self.timeout,
+                last_emit: Instant::now(),
+                state: State::New,
+            }),
+            _ => {
+                unreachable!()
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum State {
+    New,
+    // Press is emitted, waiting for repeat/release.
+    Active,
+    // Press is squashed, waiting for repeat/release.
+    Squash,
+    // Key not physically pressed, waiting for timeout.
+    Inactive,
+    Done,
+}
+
+#[derive(Debug)]
+pub struct ActiveThrottleOperator {
+    key: Key,
+    timeout: Duration,
+    // Is set to 'now' just before entering Active state with press-event.
+    last_emit: Instant,
+    state: State,
+}
+
+impl ActiveOperator for ActiveThrottleOperator {
+    fn on_press(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
+        match &mut self.state {
+            State::New => {
+                debug_assert_eq!(key_event.key, self.key);
+
+                self.state = State::Active;
+                self.last_emit = Instant::now();
+                OperatorAction::Partial(vec![Emit::key_event(device, key_event.clone())], vec![])
+            }
+            State::Active => {
+                if key_event.key == self.key {
+                    // spurious
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Squash => {
+                if key_event.key == self.key {
+                    // spurious
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Inactive => {
+                if Instant::now().duration_since(self.last_emit) > self.timeout {
+                    if key_event.key == self.key {
+                        // Pressed again before timeout.
+                        self.state = State::New;
+                        self.on_press(device, key_event)
+                    } else {
+                        self.state = State::Done;
+                        OperatorAction::Done(vec![], vec![Event::key_event2(device, key_event.clone())])
+                    }
+                } else {
+                    if key_event.key == self.key {
+                        // Begin squash
+                        self.state = State::Squash;
+                        OperatorAction::Partial(vec![], vec![])
+                    } else {
+                        OperatorAction::Unhandled
+                    }
+                }
+            }
+            State::Done => {
+                unreachable!()
+            }
+        }
+    }
+
+    fn on_release(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
+        match &mut self.state {
+            State::New => unreachable!(),
+            State::Active => {
+                if key_event.key == self.key {
+                    self.state = State::Inactive;
+                    OperatorAction::Partial(vec![Emit::key_event(device, key_event.clone())], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Squash => {
+                if key_event.key == self.key {
+                    self.state = State::Inactive;
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Inactive => {
+                if key_event.key == self.key {
+                    // spurious
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Done => {
+                unreachable!()
+            }
+        }
+    }
+
+    fn on_repeat(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
+        match &mut self.state {
+            State::New => unreachable!(),
+            State::Active => {
+                if key_event.key == self.key {
+                    OperatorAction::Partial(vec![Emit::key_event(device, key_event.clone())], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Squash => {
+                if key_event.key == self.key {
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Inactive => {
+                if key_event.key == self.key {
+                    // spurious
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Done => {
+                unreachable!()
+            }
+        }
+    }
+
+    fn on_tick(&mut self) -> OperatorAction {
+        OperatorAction::Unhandled
+    }
+
+    fn on_other(&mut self, _event: &Event) -> OperatorAction {
+        OperatorAction::Unhandled
+    }
+}

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -3,6 +3,7 @@ use crate::config::expmap_operator::ExpmapAction;
 use crate::device::InputDeviceInfo;
 use crate::emit_handler::Emit;
 use crate::event::{Event, KeyEvent, KeyValue};
+use crate::event_handler::{PRESS, RELEASE, REPEAT};
 use std::fmt::Debug;
 use std::rc::Rc;
 
@@ -31,7 +32,45 @@ pub enum OperatorAction {
 }
 
 pub trait ActiveOperator: Debug {
-    fn on_event(&mut self, event: &Event) -> OperatorAction;
+    /// Either implement this method, or each of the methods called by this one.
+    fn on_event(&mut self, event: &Event) -> OperatorAction {
+        match event {
+            Event::KeyEvent(device, key_event) => {
+                if key_event.value() == PRESS {
+                    self.on_press(device.clone(), key_event)
+                } else if key_event.value() == RELEASE {
+                    self.on_release(device.clone(), key_event)
+                } else if key_event.value() == REPEAT {
+                    self.on_repeat(device.clone(), key_event)
+                } else {
+                    // Invalid
+                    OperatorAction::Unhandled
+                }
+            }
+            Event::Tick => self.on_tick(),
+            _ => self.on_other(event),
+        }
+    }
+
+    fn on_press(&mut self, _device: Rc<InputDeviceInfo>, _key_event: &KeyEvent) -> OperatorAction {
+        unreachable!()
+    }
+
+    fn on_release(&mut self, _device: Rc<InputDeviceInfo>, _key_event: &KeyEvent) -> OperatorAction {
+        unreachable!()
+    }
+
+    fn on_repeat(&mut self, _device: Rc<InputDeviceInfo>, _key_event: &KeyEvent) -> OperatorAction {
+        unreachable!()
+    }
+
+    fn on_tick(&mut self) -> OperatorAction {
+        unreachable!()
+    }
+
+    fn on_other(&mut self, _event: &Event) -> OperatorAction {
+        unreachable!()
+    }
 }
 
 pub fn map_actions(actions: &Vec<ExpmapAction>, device: Rc<InputDeviceInfo>, value: KeyValue) -> Vec<Emit> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,6 +7,8 @@ use crate::config::Config;
 use crate::device::InputDeviceInfo;
 use crate::event::{Event, KeyEvent, KeyValue, RelativeEvent};
 use crate::event_handler::EventHandler;
+use crate::operator_handler::OperatorHandler;
+use crate::timeout_manager::TimeoutManager;
 use evdev::{KeyCode as Key, RelativeAxisCode};
 use indoc::indoc;
 use nix::sys::timerfd::{ClockId, TimerFd, TimerFlags};
@@ -568,6 +570,11 @@ pub fn parse_config_for_test(str: &str) -> Config {
     config.keymap_table = build_keymap_table(&config.keymap);
     validate_config_file(&config).unwrap();
     config
+}
+
+pub fn get_handler_from_config(config: &str) -> anyhow::Result<OperatorHandler> {
+    let config = parse_config_for_test(config);
+    Ok(OperatorHandler::new(&config.experimental_map, Rc::new(TimeoutManager::new())))
 }
 
 pub fn assert_events(actual: impl AsRef<Vec<Event>>, expected: impl AsRef<Vec<Event>>) {

--- a/src/tests_operator_throttle.rs
+++ b/src/tests_operator_throttle.rs
@@ -1,0 +1,187 @@
+use crate::event::Event;
+use crate::operator_handler::OperatorHandler;
+use crate::tests::{assert_events, get_handler_from_config};
+use evdev::KeyCode as Key;
+use indoc::indoc;
+use std::time::Duration;
+
+static TIMEOUT: Duration = Duration::from_millis(10);
+
+fn get_handler() -> OperatorHandler {
+    get_handler_from_config(indoc! {"
+        experimental_map:
+            - remap:
+                A: { throttle_ms: 10 }
+        "})
+    .unwrap()
+}
+
+#[test]
+fn test_throttle_mess() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    std::thread::sleep(TIMEOUT); // So it goes into done state
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_throttle() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    std::thread::sleep(TIMEOUT); // So it goes into done state
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_throttle_squash() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    // Events are squashed
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+
+    std::thread::sleep(TIMEOUT); // So it goes into done state
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_throttle_timeout_at_key_press() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    std::thread::sleep(TIMEOUT); // The key event is the first after timeout.
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    std::thread::sleep(TIMEOUT); // So it goes into done state
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_throttle_timeout_at_other_key_press() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    std::thread::sleep(TIMEOUT);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_throttle_surrounded_at_press() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    std::thread::sleep(TIMEOUT);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_throttle_surrounded_at_release() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    std::thread::sleep(TIMEOUT);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_throttle_surrounded_at_press_inactive() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+
+    std::thread::sleep(TIMEOUT);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_throttle_surrounded_at_release_inactive() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    std::thread::sleep(TIMEOUT);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_throttle_spurious() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]); // spurious
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![]); // spurious
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]); // spurious
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]); // spurious
+
+    std::thread::sleep(TIMEOUT);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}


### PR DESCRIPTION
ThrottleOperator controls how fast a key can be used. It works by letting the first event through (including the following repeats and release). After that it squashes all events from that key until timeout is reached where the key can again be used.

Example usage:
```yml
experimental_map:
  - remap:
      kpminus: { throttle_ms: 2000 }
```