### PR TITLE
Add Oneshot operator

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -30,6 +30,7 @@ Each method has pros and cons, it's worth checking out the pages before choosing
 - [Double tap](reference_double_tap.md)
 - [Chords (simultaneous keys)](reference_chords.md)
 - [Throttle keys](reference_throttle.md)
+- [Oneshot key](reference_oneshot.md)
 - [FreeBSD](reference_freebsd.md)
 - [Scripting](reference_scripting.md)
 

--- a/doc/reference_oneshot.md
+++ b/doc/reference_oneshot.md
@@ -1,0 +1,47 @@
+## Oneshot a key (aka: sticky key)
+
+A oneshot key emits an action at press. The action is kept until next key is pressed and released just after.
+
+Fx when a oneshot key is pressed and released, then is fx `LeftShift` hold, and it can be used to capitalize the next letter.
+
+Working since v0.15.12
+
+### Experimental
+
+Experimental means this feature is likely to change in the future as it's improved. This
+can break configuration files in any version update of xremap, and will be noted in CHANGELOG.md.
+
+Features available in `modmap` like: `device`, `mode`, key-to-key mapping,
+multi-purpose key and press/release key don't work in `experimental_map`.
+But application-specific remapping with `application` and `window` works since `v0.15.5`.
+
+### Description
+
+The action is emitted at press and kept when the oneshot key is released.
+The action remains pressed until next key is pressed and releases immediately after that key.
+
+If on the other hand, the oneshot key is held when the next key is pressed, it functions
+completely normal. That is, the action is released when the oneshot key is released.
+
+The third option is that the oneshot key is itself repressed before other keys are pressed.
+The action is cancelled in that case.
+
+The oneshot action is not interrupted by mouse movement or scroll. But is interrupted by mouse click if `--mouse` argument is used.
+
+Note: Other modifiers and other oneshot keys also interrupt a oneshot action.
+It might not be the intended behavior, and is subject to change, based on user feedback.
+
+### Example: Use shift as oneshot shift
+
+```yml
+experimental_map:
+  - remap:
+      s_l: { oneshot: s_l }
+```
+
+`Shift` still functions as a normal modifier.
+
+## References
+
+- https://docs.qmk.fm/one_shot_keys
+- https://man.archlinux.org/man/extra/keyd/keyd.1.en#Example_3

--- a/src/config/expmap_operator.rs
+++ b/src/config/expmap_operator.rs
@@ -1,6 +1,7 @@
 use crate::config::deserialize_single_field;
 use crate::config::deserializers::{deserialize_duration, DurationWrapper};
 use crate::config::key::deserialize_key;
+use crate::config::modmap::KeyWrapper;
 use evdev::KeyCode as Key;
 use serde::{Deserialize, Deserializer};
 use std::fmt::Debug;
@@ -12,10 +13,16 @@ pub enum ExpmapOperator {
     DoubleTap(DoubleTap),
     #[serde(deserialize_with = "deserialize_throttle")]
     Throttle(Duration),
+    #[serde(deserialize_with = "deserialize_oneshot")]
+    OneShot(Key),
 }
 
 pub fn deserialize_throttle<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Duration, D::Error> {
     Ok(deserialize_single_field::<D, DurationWrapper>(deserializer, "throttle_ms")?.0)
+}
+
+pub fn deserialize_oneshot<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Key, D::Error> {
+    Ok(deserialize_single_field::<D, KeyWrapper>(deserializer, "oneshot")?.0)
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/emit_handler.rs
+++ b/src/emit_handler.rs
@@ -1,23 +1,13 @@
 use crate::device::InputDeviceInfo;
-use crate::event::{Event, KeyEvent, KeyValue};
+use crate::event::{Event, KeyEvent};
 use crate::event_handler::{MODIFIER_KEYS, PRESS, RELEASE, REPEAT};
 use evdev::KeyCode as Key;
 use log::warn;
 use std::rc::Rc;
 
 #[derive(Debug, Clone)]
-pub struct EmitCombo {
-    pub key: Key,
-    pub modifiers: Vec<Key>,
-}
-
-#[derive(Debug, Clone)]
 pub enum Emit {
     Single(Event),
-    #[allow(dead_code)]
-    KeyComboWithHold(Rc<InputDeviceInfo>, EmitCombo),
-    #[allow(dead_code)]
-    SyncModidiers(Rc<InputDeviceInfo>),
 }
 
 impl Emit {
@@ -42,10 +32,9 @@ impl EmitHandler {
     }
 
     #[cfg(test)]
-    pub fn assert_emitted_modifiers_are_synced(&self) {
-        assert!(self
-            .sync_emitted_modifiers(crate::tests::get_input_device_info(), &self.physical_modifiers)
-            .is_empty());
+    pub fn assert_base_state(&self) {
+        assert!(self.physical_modifiers.is_empty());
+        assert!(self.emitted_modifiers.is_empty());
     }
 
     pub fn map_output(&mut self, events: Vec<Emit>) -> Vec<Event> {
@@ -57,27 +46,6 @@ impl EmitHandler {
                     update_modifier_state(&mut self.emitted_modifiers, &event);
                     result.push(event);
                 }
-                Emit::KeyComboWithHold(device, key_combo) => {
-                    let mut events = self.sync_emitted_modifiers(device.clone(), &key_combo.modifiers);
-
-                    self.emitted_modifiers = key_combo.modifiers.clone();
-
-                    assert!(!MODIFIER_KEYS.contains(&key_combo.key));
-
-                    events.extend(vec![
-                        Event::KeyEvent(device.clone(), KeyEvent::new(key_combo.key, KeyValue::Press)),
-                        Event::KeyEvent(device, KeyEvent::new(key_combo.key, KeyValue::Release)),
-                    ]);
-
-                    result.extend(events);
-                }
-                Emit::SyncModidiers(device) => {
-                    let events = self.sync_emitted_modifiers(device, &self.physical_modifiers);
-
-                    self.emitted_modifiers = self.physical_modifiers.clone();
-
-                    result.extend(events);
-                }
             }
         }
 
@@ -86,39 +54,6 @@ impl EmitHandler {
 
     pub fn on_event(&mut self, event: &Event) {
         update_modifier_state(&mut self.physical_modifiers, event)
-    }
-
-    fn sync_emitted_modifiers(&self, device: Rc<InputDeviceInfo>, modifiers: &[Key]) -> Vec<Event> {
-        let modifiers_to_release: Vec<Event> = self
-            .emitted_modifiers
-            .iter()
-            .filter_map(|key| {
-                if modifiers.contains(key) {
-                    None
-                } else {
-                    // Emitted modifier that should not be pressed.
-                    Some(Event::KeyEvent(device.clone(), KeyEvent::new(*key, KeyValue::Release)))
-                }
-            })
-            .collect();
-
-        let modifiers_to_press: Vec<Event> = modifiers
-            .iter()
-            .filter_map(|key| {
-                if self.emitted_modifiers.contains(key) {
-                    None
-                } else {
-                    // Modifier that hasn't been emitted yet.
-                    Some(Event::KeyEvent(device.clone(), KeyEvent::new(*key, KeyValue::Press)))
-                }
-            })
-            .collect();
-
-        let mut events = modifiers_to_release;
-
-        events.extend(modifiers_to_press);
-
-        events
     }
 }
 

--- a/src/emit_handler.rs
+++ b/src/emit_handler.rs
@@ -1,5 +1,5 @@
 use crate::device::InputDeviceInfo;
-use crate::event::{Event, KeyEvent};
+use crate::event::{Event, KeyEvent, KeyValue};
 use crate::event_handler::{MODIFIER_KEYS, PRESS, RELEASE, REPEAT};
 use evdev::KeyCode as Key;
 use log::warn;
@@ -11,6 +11,16 @@ pub enum Emit {
 }
 
 impl Emit {
+    pub fn key_release(device: Rc<InputDeviceInfo>, code: Key) -> Emit {
+        Emit::Single(Event::KeyEvent(device, KeyEvent::new(code, KeyValue::Release)))
+    }
+    pub fn key_press(device: Rc<InputDeviceInfo>, code: Key) -> Emit {
+        Emit::Single(Event::KeyEvent(device, KeyEvent::new(code, KeyValue::Press)))
+    }
+    pub fn key_repeat(device: Rc<InputDeviceInfo>, code: Key) -> Emit {
+        Emit::Single(Event::KeyEvent(device, KeyEvent::new(code, KeyValue::Repeat)))
+    }
+
     pub fn key_event(device: Rc<InputDeviceInfo>, key_event: KeyEvent) -> Emit {
         Emit::Single(Event::KeyEvent(device, key_event))
     }

--- a/src/emit_handler.rs
+++ b/src/emit_handler.rs
@@ -43,6 +43,12 @@ impl EmitHandler {
         for event in events {
             match event {
                 Emit::Single(event) => {
+                    let event = match event {
+                        // Extract the event, that operators have ignored.
+                        Event::ByPassLocal(event) => *event,
+                        event => event,
+                    };
+
                     update_modifier_state(&mut self.emitted_modifiers, &event);
                     result.push(event);
                 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -16,6 +16,13 @@ pub enum Event {
     OverrideTimeout,
     // Ticks for operators
     Tick,
+    // By pass active operators adn static operators on the same level.
+    //  This has the meaning, that the emitted operator has handled the event, created
+    //  this synthetic event, that must not have effect on the same level.
+    // The bypass-event can at most interrupt other operators or actions emitted.
+    // This event is never emitted from EmitHandler, so it's strictly local to the level.
+    #[allow(warnings)]
+    ByPassLocal(Box<Event>),
 }
 
 impl Event {

--- a/src/event.rs
+++ b/src/event.rs
@@ -26,6 +26,9 @@ pub enum Event {
 }
 
 impl Event {
+    pub fn key_release2(device: Rc<InputDeviceInfo>, code: Key) -> Event {
+        Event::KeyEvent(device, KeyEvent::new(code, KeyValue::Release))
+    }
     pub fn key_event2(device: Rc<InputDeviceInfo>, key_event: KeyEvent) -> Event {
         Event::KeyEvent(device, key_event)
     }

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -145,6 +145,7 @@ impl EventHandler {
                     Event::Tick => {
                         // Can be ignored. It's for operators.
                     }
+                    Event::ByPassLocal(_) => unreachable!(),
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod main_controller;
 mod main_impl;
 mod operator_double_tap;
 mod operator_handler;
+mod operator_oneshot;
 mod operator_sim;
 mod operator_throttle;
 mod operators;

--- a/src/operator_handler.rs
+++ b/src/operator_handler.rs
@@ -75,11 +75,7 @@ impl OperatorHandler {
     pub fn assert_base_state(&self) {
         assert!(self.active.is_empty());
         assert!(self.candidates.is_none());
-    }
-
-    #[cfg(test)]
-    pub fn assert_emitted_modifiers_are_synced(&self) {
-        self.emit_handler.assert_emitted_modifiers_are_synced();
+        self.emit_handler.assert_base_state();
     }
 
     #[cfg(test)]

--- a/src/operator_handler.rs
+++ b/src/operator_handler.rs
@@ -5,6 +5,7 @@ use crate::emit_handler::{Emit, EmitHandler};
 use crate::event::Event;
 use crate::event_handler::PRESS;
 use crate::operator_double_tap::DoubleTapOperator;
+use crate::operator_oneshot::OneshotOperator;
 use crate::operator_sim::SimOperator;
 use crate::operator_throttle::ThrottleOperator;
 use crate::operators::{ActiveOperator, OperatorAction, OperatorEntry, StaticOperator};
@@ -58,6 +59,7 @@ impl OperatorHandler {
                         DoubleTapOperator::get_ops(*key, dbltap, timeout_manager.clone())
                     }
                     ExpmapOperator::Throttle(timeout) => ThrottleOperator::get_ops(*key, *timeout),
+                    ExpmapOperator::OneShot(action) => OneshotOperator::get_ops(*key, *action),
                 };
                 append(operators, &mut lookup_map, expmap);
             }

--- a/src/operator_oneshot.rs
+++ b/src/operator_oneshot.rs
@@ -1,0 +1,202 @@
+use crate::device::InputDeviceInfo;
+use crate::emit_handler::Emit;
+use crate::event::{Event, KeyEvent};
+use crate::operators::{ActiveOperator, OperatorAction, StaticOperator};
+use evdev::KeyCode as Key;
+use std::rc::Rc;
+use std::vec;
+
+#[derive(Debug, Clone)]
+pub struct OneshotOperator {
+    key: Key,
+    action: Key,
+}
+
+impl OneshotOperator {
+    pub fn get_ops(key: Key, action: Key) -> Vec<(Key, Box<dyn StaticOperator>)> {
+        vec![(key, Box::new(OneshotOperator { key, action }))]
+    }
+}
+
+impl StaticOperator for OneshotOperator {
+    fn get_active_operator(&self, event: &Event) -> Box<dyn ActiveOperator> {
+        match event {
+            Event::KeyEvent(_, _) => Box::new(ActiveOneshotOperator {
+                key: self.key,
+                action: self.action.clone(),
+                state: State::New,
+            }),
+            _ => {
+                unreachable!()
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum State {
+    New,
+    Pressed,
+    Oneshot,
+    StandardMod,
+    Cancel,
+    Done,
+}
+
+#[derive(Debug)]
+pub struct ActiveOneshotOperator {
+    key: Key,
+    action: Key,
+    state: State,
+}
+
+impl ActiveOperator for ActiveOneshotOperator {
+    fn on_press(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
+        match &mut self.state {
+            State::New => {
+                self.state = State::Pressed;
+                OperatorAction::Partial(vec![Emit::key_press(device.clone(), self.action)], vec![])
+            }
+            State::Pressed => {
+                if key_event.key == self.key {
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    self.state = State::StandardMod;
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Oneshot => {
+                if key_event.key == self.key {
+                    // Cancel because it's repressed.
+                    self.state = State::Cancel;
+                    OperatorAction::Partial(
+                        vec![
+                            Emit::key_release(device.clone(), self.action),
+                            // This is emitted, so it doesn't activate the same operator again.
+                            Emit::key_event(device.clone(), key_event.clone()),
+                        ],
+                        vec![],
+                    )
+                } else {
+                    let unhandled = vec![
+                        Event::KeyEvent(device.clone(), key_event.clone()),
+                        // Releasing after interrupting key, means it must go in unhandled array.
+                        Event::ByPassLocal(Box::new(Event::key_release2(device.clone(), self.action))),
+                    ];
+                    self.state = State::Done;
+                    OperatorAction::Done(vec![], unhandled)
+                }
+            }
+            State::StandardMod => {
+                if key_event.key == self.key {
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    // Normal key
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Cancel => {
+                if key_event.key == self.key {
+                    // spurious
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Done => {
+                unreachable!()
+            }
+        }
+    }
+
+    fn on_release(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
+        match &mut self.state {
+            State::New => unreachable!(),
+            State::Pressed => {
+                if key_event.key == self.key {
+                    // Delay action-release.
+                    self.state = State::Oneshot;
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    // Release doesn't interrupt.
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Oneshot => {
+                if key_event.key == self.key {
+                    // Spurious is suppressed
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    // Release doesn't consume the oneshot.
+                    OperatorAction::Unhandled
+                }
+            }
+            State::StandardMod => {
+                if key_event.key == self.key {
+                    self.state = State::Done;
+                    OperatorAction::Done(vec![Emit::key_release(device.clone(), self.action)], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Cancel => {
+                if key_event.key == self.key {
+                    self.state = State::Done;
+                    OperatorAction::Done(vec![Emit::key_release(device.clone(), self.key)], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Done => {
+                unreachable!()
+            }
+        }
+    }
+
+    fn on_repeat(&mut self, device: Rc<InputDeviceInfo>, key_event: &KeyEvent) -> OperatorAction {
+        match &mut self.state {
+            State::New => unreachable!(),
+            State::Pressed => {
+                if key_event.key == self.key {
+                    OperatorAction::Partial(vec![Emit::key_repeat(device.clone(), self.action)], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Oneshot => {
+                if key_event.key == self.key {
+                    // Spurious
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::StandardMod => {
+                if key_event.key == self.key {
+                    // Spurious
+                    OperatorAction::Partial(vec![], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Cancel => {
+                if key_event.key == self.key {
+                    OperatorAction::Partial(vec![Emit::key_repeat(device.clone(), self.key)], vec![])
+                } else {
+                    OperatorAction::Unhandled
+                }
+            }
+            State::Done => {
+                unreachable!()
+            }
+        }
+    }
+
+    fn on_tick(&mut self) -> OperatorAction {
+        OperatorAction::Unhandled
+    }
+
+    fn on_other(&mut self, _event: &Event) -> OperatorAction {
+        OperatorAction::Unhandled
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod tests_modmap_press_release_key;
 mod tests_nested_remap;
 mod tests_operator_double_tap;
 mod tests_operator_handler;
+mod tests_operator_oneshot;
 mod tests_operator_sim;
 mod tests_operator_throttle;
 mod tests_throttle_emit;

--- a/src/tests/tests_operator_double_tap.rs
+++ b/src/tests/tests_operator_double_tap.rs
@@ -30,7 +30,6 @@ fn test_dbltap_key_not_matching() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -47,6 +46,11 @@ fn test_dbltap_at_first_press_not_canceled_by_other_non_matching() {
     );
 
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
+
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTALT)]),
+        vec![Event::key_release(Key::KEY_LEFTALT)],
+    );
 
     handler.assert_base_state();
 }
@@ -74,7 +78,6 @@ fn test_dbltap_at_first_press_canceled_by_timeout() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -89,7 +92,6 @@ fn test_dbltap_at_first_press_repeated() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -112,7 +114,6 @@ fn test_dbltap_when_tapped_not_canceled_by_other_non_matching() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -135,7 +136,6 @@ fn test_dbltap_when_tapped_canceled_by_timeout() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -162,7 +162,6 @@ fn test_dbltap_when_tapped_canceled_by_timeout_with_rolled_key() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -189,7 +188,6 @@ fn test_dbltap_when_tapped_canceled_by_timeout_with_modded_key() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -216,7 +214,6 @@ fn test_dbltap_when_tapped_canceled_by_timeout_with_distinct_key() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -240,7 +237,6 @@ fn test_dbltap_spurious_events() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -254,7 +250,6 @@ fn test_dbltap() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -274,7 +269,6 @@ fn test_dbltap_twice() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -294,7 +288,6 @@ fn test_dbltap_then_tick_before_release() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -309,7 +302,6 @@ fn test_dbltap_then_repeat_triggering_key() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -332,7 +324,6 @@ fn test_dbltap_then_repeat_ordinary_key() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -352,7 +343,6 @@ fn test_dbltap_surrounded_at_first_press() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -372,7 +362,6 @@ fn test_dbltap_surrounded_at_tapped() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -397,5 +386,4 @@ fn test_dbltap_surrounded_at_double_tapped() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTCTRL)]), vec![Event::key_release(Key::KEY_1)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }

--- a/src/tests/tests_operator_handler.rs
+++ b/src/tests/tests_operator_handler.rs
@@ -47,7 +47,6 @@ fn test_operator_handler_picks_heighest_candidate() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -74,7 +73,6 @@ fn test_operator_handler_picks_heighest_candidate_after_lowest_has_canceled() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -92,7 +90,6 @@ fn test_operator_handler_picks_lowest_candidate_when_heighest_cancels() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_C)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -117,7 +114,6 @@ fn test_operator_handler_picks_finished_lowest_candidate_when_heighest_cancels()
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -154,7 +150,6 @@ fn test_operator_handler_picks_lowest_candidate_done_a_while_when_heighest_match
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -185,7 +180,6 @@ fn test_operator_handler_picks_lowest_candidate_finished_a_while_when_heighest_c
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -208,7 +202,6 @@ fn test_operator_handler_picks_lowest_candidate_when_canceled_by_timeout() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -222,7 +215,6 @@ fn test_operator_handler_two_candidates_that_both_cancel() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -246,7 +238,6 @@ fn test_operator_handler_unhandled_events_are_passed_to_next_operator_when_cance
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -269,7 +260,6 @@ fn test_operator_handler_unhandled_events_are_passed_to_next_operator_at_match()
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -294,7 +284,6 @@ fn test_operator_handler_unhandled_events_are_passed_to_static_operators_when_do
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -312,7 +301,6 @@ fn test_operator_handler_candidate_match_in_one_batch() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -325,7 +313,6 @@ fn test_operator_handler_candidate_cancels_in_one_batch() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -358,5 +345,4 @@ fn test_operator_handler_candidate_with_many_actions() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }

--- a/src/tests/tests_operator_oneshot.rs
+++ b/src/tests/tests_operator_oneshot.rs
@@ -1,0 +1,328 @@
+use crate::event::Event;
+use crate::operator_handler::OperatorHandler;
+use crate::tests::{assert_events, get_handler_from_config};
+use evdev::KeyCode as Key;
+use indoc::indoc;
+
+fn get_handler() -> OperatorHandler {
+    get_handler_from_config(indoc! {"
+        experimental_map:
+            - remap:
+                s_l: { oneshot: a_l }
+        "})
+    .unwrap()
+}
+
+#[test]
+fn test_oneshot_used() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(
+        handler.map_evs(vec![Event::key_repeat(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_repeat(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+    // spurious
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_LEFTSHIFT)]), vec![]);
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_A)]),
+        vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_cancelled_by_repress() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![
+            Event::key_release(Key::KEY_LEFTALT),
+            Event::key_press(Key::KEY_LEFTSHIFT),
+        ],
+    );
+    assert_events(
+        handler.map_evs(vec![Event::key_repeat(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_repeat(Key::KEY_LEFTSHIFT)],
+    );
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_release(Key::KEY_LEFTSHIFT)],
+    );
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_interrupted_then_released_staggered() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_A)]), vec![Event::key_repeat(Key::KEY_A)]);
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_release(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_interrupted_by_two_keys() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_B)]), vec![Event::key_press(Key::KEY_B)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_B)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_release(Key::KEY_LEFTALT)],
+    );
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_interrupted_then_released_modded() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    // spurious
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_LEFTSHIFT)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_release(Key::KEY_LEFTALT)],
+    );
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_used_with_two_keys_in_batch() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_A), Event::key_press(Key::KEY_K)]),
+        vec![
+            Event::key_press(Key::KEY_A),
+            Event::key_release(Key::KEY_LEFTALT),
+            Event::key_press(Key::KEY_K),
+        ],
+    );
+
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_A), Event::key_release(Key::KEY_K)]),
+        vec![Event::key_release(Key::KEY_A), Event::key_release(Key::KEY_K)],
+    );
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_used_with_press_and_repeat_in_batch() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_A), Event::key_repeat(Key::KEY_A)]),
+        vec![
+            Event::key_press(Key::KEY_A),
+            Event::key_release(Key::KEY_LEFTALT),
+            Event::key_repeat(Key::KEY_A),
+        ],
+    );
+
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_surround_at_press() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_K)]), vec![Event::key_repeat(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_A)]),
+        vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_surround_press_and_release() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_repeat(Key::KEY_K)]), vec![Event::key_repeat(Key::KEY_K)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_A)]),
+        vec![Event::key_press(Key::KEY_A), Event::key_release(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_surround_cancelling_release() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![
+            Event::key_release(Key::KEY_LEFTALT),
+            Event::key_press(Key::KEY_LEFTSHIFT),
+        ],
+    );
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_release(Key::KEY_LEFTSHIFT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_surround_cancelling_press() {
+    let mut handler = get_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![
+            Event::key_release(Key::KEY_LEFTALT),
+            Event::key_press(Key::KEY_LEFTSHIFT),
+        ],
+    );
+
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_release(Key::KEY_LEFTSHIFT)],
+    );
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_spuriously_pressed() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    // Spurious in pressed-state
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+    // Spurious in oneshot-state
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]), vec![]);
+
+    // Tap again to cancel oneshot state.
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![
+            Event::key_release(Key::KEY_LEFTALT),
+            Event::key_press(Key::KEY_LEFTSHIFT),
+        ],
+    );
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_release(Key::KEY_LEFTSHIFT)],
+    );
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_oneshot_spuriously_when_interrupted() {
+    let mut handler = get_handler();
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_press(Key::KEY_LEFTALT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+
+    //spurious
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_LEFTSHIFT)]), vec![]);
+
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+    assert_events(
+        handler.map_evs(vec![Event::key_release(Key::KEY_LEFTSHIFT)]),
+        vec![Event::key_release(Key::KEY_LEFTALT)],
+    );
+
+    handler.assert_base_state();
+}

--- a/src/tests/tests_operator_sim.rs
+++ b/src/tests/tests_operator_sim.rs
@@ -36,7 +36,6 @@ fn symkey_test_first_key_released_before_second_is_pressed() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -50,7 +49,6 @@ fn symkey_pressed_then_timeout() {
     assert_events(handler.map_evs(vec![Event::Tick]), vec![Event::key_press(Key::KEY_A)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -75,7 +73,6 @@ fn symkey_pressed_then_release_of_old_other_key() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -85,7 +82,6 @@ fn simkey_test_releasing_key_does_not_start_matching() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -104,7 +100,6 @@ fn symkey_emitted_then_timeout() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -117,7 +112,6 @@ fn symkey_test_emitted_key_is_released_when_first_trigger_key_is_released() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -132,7 +126,6 @@ fn symkey_test_trigger_then_modded_release() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -147,7 +140,6 @@ fn symkey_test_trigger_then_rolled_release() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -162,7 +154,6 @@ fn symkey_test_trigger_in_reverse_then_modded_release() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -177,7 +168,6 @@ fn symkey_test_trigger_in_reverse_then_rolled_release() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -196,7 +186,6 @@ fn symkey_released_then_timeout() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -217,7 +206,6 @@ fn symkey_test_second_key_can_start_matching_right_after_other_release() {
     );
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -236,7 +224,6 @@ fn symkey_test_surrounded_at_first_press() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -258,7 +245,6 @@ fn symkey_test_surrounded_at_first_press_and_cancel() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![Event::key_release(Key::KEY_B)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -277,7 +263,6 @@ fn symkey_test_surrounded_at_emit() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -293,7 +278,6 @@ fn symkey_test_surrounded_at_release() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -309,7 +293,6 @@ fn symkey_test_surrounded_at_done() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -342,7 +325,6 @@ fn symkey_test_repeat() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -378,7 +360,6 @@ fn symkey_test_repeat_after_release() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_B)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }
 
 #[test]
@@ -393,5 +374,4 @@ fn symkey_test_3_simkeys() {
     assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_E)]), vec![]);
 
     handler.assert_base_state();
-    handler.assert_emitted_modifiers_are_synced();
 }


### PR DESCRIPTION
Oneshot key is well-known and documentation is included in the PR.

One problem still remaining is whether modifiers and other oneshot keys should interrupt oneshot keys. They do in this implementation, but I'm unsure if that is a good default.

Example:

```yml
experimental_map:
  - remap:
      s_l: { oneshot: s_l }
```