### PR TITLE
Add select operator

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -31,6 +31,7 @@ Each method has pros and cons, it's worth checking out the pages before choosing
 - [Chords (simultaneous keys)](reference_chords.md)
 - [Throttle keys](reference_throttle.md)
 - [Oneshot key](reference_oneshot.md)
+- [Select between operators](reference_select.md)
 - [FreeBSD](reference_freebsd.md)
 - [Scripting](reference_scripting.md)
 

--- a/doc/reference_select.md
+++ b/doc/reference_select.md
@@ -1,0 +1,83 @@
+## Select between operators
+
+`select` chooses exactly one of several operators, that take a small `timeout` to decide if they match.
+
+Think of operators as small programs, that decide how keys are remapped. They take key events
+as input and output new key events.
+
+Examples of operators are: [Double tap](reference_double_tap.md), [Chords (simultaneous keys)](reference_chords.md), [Oneshot key](reference_oneshot.md) and [Throttle keys](reference_throttle.md).
+
+### Experimental
+
+Experimental means this feature is likely to change in the future as it's improved. This
+can break configuration files in any version update of xremap, and will be noted in CHANGELOG.md.
+
+Features available in `modmap` like: `device`, `mode`, key-to-key mapping,
+multi-purpose key and press/release key don't work in `experimental_map`.
+But application-specific remapping with `application` and `window` works since `v0.15.5`.
+
+### Description
+
+`select` takes a list of operators and chooses the first in order, that matches. That operator
+will get all the events, and the other operators will get no events and have no visible effect.
+
+Operators have the ability to defer decision of whether they match events, the events are buffered
+until a decision is made. This makes it possible for fx `double` tap to completely squash the
+key that triggered it.
+
+Operators of this type should have a short timeout to make sense. Otherwise would the keyboard
+just freeze. But if it's short enough the delay can be tolerated or even unnoticable.
+
+## Examples
+
+### Example: Fast and slow double tap
+
+The following allows two different actions depending on how fast double tap is performed.
+The first operator `double` takes precedence. If it doesn't match will the
+second `double` get a chance to match. And eventually if it doesn't match after `300ms`
+will the event fallthrough to next level, which is `modmap`.
+
+```yml
+experimental_map:
+  - remap:
+      A:
+        select:
+          - double: B
+            timeout: 150
+          - double: C
+            timeout: 300 # This timeout is also started when the key is pressed.
+```
+
+### Example: Double tap and oneshot action otherwise
+
+The following allows an action when double tapping and a oneshot otherwise.
+If the double tap doesn't match (default timeout: 200ms), will it look like
+it never existed, and the `oneshot` action is emitted.
+
+```yml
+experimental_map:
+  - remap:
+      s_l:
+        select:
+          - { double: B }
+          - { oneshot: s_l }
+```
+
+Note: An active oneshot will emit a press of `s_l` to next level when cancelled, so `double` doesn't see it.
+So the first `s_l`, in a double tap in that state, will cancel
+oneshot and go through, and the next `s_l` will not activate `double`.
+Which mean oneshot will activate again. That's very counterintuitive.
+
+The above example is equivalent to the following:
+
+```yml
+experimental_map:
+  - remap:
+      s_l: { double: B }
+  - remap:
+      s_l: { oneshot: s_l }
+```
+
+That's because the second remap has the same `application` and `window` matcher, which is no one.
+The purpose of more than one `remap` group is the extra properties on those groups.
+Everything in `experimental_map` will eventually just be collected into _one_ long list of things.

--- a/src/config/deserializers.rs
+++ b/src/config/deserializers.rs
@@ -17,6 +17,27 @@ impl<T> VecOrSingle<T> {
     }
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum VectorOrSingleOrNull<T> {
+    NoAction,
+    Action(T),
+    Actions(Vec<T>),
+}
+
+impl<T> VectorOrSingleOrNull<T> {
+    pub fn into_vec(self) -> Vec<T> {
+        match self {
+            VectorOrSingleOrNull::NoAction => vec![],
+            VectorOrSingleOrNull::Action(action) => vec![action],
+            VectorOrSingleOrNull::Actions(actions) => actions,
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct DurationWrapper(#[serde(deserialize_with = "deserialize_duration")] pub Duration);
+
 pub fn deserialize_duration<'de, D>(deserializer: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
@@ -24,6 +45,3 @@ where
     let millis = u64::deserialize(deserializer)?;
     Ok(Duration::from_millis(millis))
 }
-
-#[derive(Deserialize, Debug)]
-pub struct DurationWrapper(#[serde(deserialize_with = "deserialize_duration")] pub Duration);

--- a/src/config/expmap.rs
+++ b/src/config/expmap.rs
@@ -19,10 +19,13 @@ pub struct Expmap {
     pub window: Option<ApplicationMatch>,
 }
 
-pub fn deserialize_experimental_remap<'de, D>(deserializer: D) -> Result<IndexMap<Key, ExpmapOperator>, D::Error>
+fn deserialize_experimental_remap<'de, D>(deserializer: D) -> Result<IndexMap<Key, ExpmapOperator>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let v = IndexMap::<KeyWrapper, ExpmapOperator>::deserialize(deserializer)?;
-    Ok(v.into_iter().map(|(KeyWrapper(k), v)| (k, v)).collect())
+    let remap = IndexMap::<KeyWrapper, ExpmapOperator>::deserialize(deserializer)?;
+    Ok(remap
+        .into_iter()
+        .map(|(KeyWrapper(key), actions)| (key, actions))
+        .collect())
 }

--- a/src/config/expmap_operator.rs
+++ b/src/config/expmap_operator.rs
@@ -1,5 +1,5 @@
 use crate::config::deserialize_single_field;
-use crate::config::deserializers::{deserialize_duration, DurationWrapper};
+use crate::config::deserializers::{deserialize_duration, DurationWrapper, VectorOrSingleOrNull};
 use crate::config::key::deserialize_key;
 use crate::config::modmap::KeyWrapper;
 use evdev::KeyCode as Key;
@@ -40,30 +40,11 @@ pub enum ExpmapAction {
     Key(Key),
 }
 
-// Used only for deserializing
-#[derive(Clone, Debug, Deserialize)]
-#[serde(untagged)]
-enum ExpmapActions<T> {
-    NoAction,
-    Action(T),
-    Actions(Vec<T>),
-}
-
-impl<T> ExpmapActions<T> {
-    pub fn into_vec(self) -> Vec<T> {
-        match self {
-            ExpmapActions::NoAction => vec![],
-            ExpmapActions::Action(action) => vec![action],
-            ExpmapActions::Actions(actions) => actions,
-        }
-    }
-}
-
 pub fn deserialize_expmap_actions<'de, D>(deserializer: D) -> Result<Vec<ExpmapAction>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    Ok(ExpmapActions::deserialize(deserializer)?.into_vec())
+    Ok(VectorOrSingleOrNull::deserialize(deserializer)?.into_vec())
 }
 
 fn default_dbltap_timeout() -> Duration {

--- a/src/config/expmap_operator.rs
+++ b/src/config/expmap_operator.rs
@@ -15,6 +15,8 @@ pub enum ExpmapOperator {
     Throttle(Duration),
     #[serde(deserialize_with = "deserialize_oneshot")]
     OneShot(Key),
+    #[serde(deserialize_with = "deserialize_select")]
+    Select(Vec<ExpmapOperator>),
 }
 
 pub fn deserialize_throttle<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Duration, D::Error> {
@@ -23,6 +25,10 @@ pub fn deserialize_throttle<'de, D: Deserializer<'de>>(deserializer: D) -> Resul
 
 pub fn deserialize_oneshot<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Key, D::Error> {
     Ok(deserialize_single_field::<D, KeyWrapper>(deserializer, "oneshot")?.0)
+}
+
+pub fn deserialize_select<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<ExpmapOperator>, D::Error> {
+    Ok(deserialize_single_field::<D, Vec<ExpmapOperator>>(deserializer, "select")?)
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -2,8 +2,9 @@ use super::device::DeviceMatcher;
 use super::key_press::Modifier;
 use crate::config::application::deserialize_string_or_vec;
 use crate::config::application::ApplicationMatch;
+use crate::config::deserializers::VectorOrSingleOrNull;
 use crate::config::key_press::KeyPress;
-use crate::config::keymap_action::{Actions, KeymapAction};
+use crate::config::keymap_action::KeymapAction;
 use evdev::KeyCode as Key;
 use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer};
@@ -32,7 +33,7 @@ where
     D: Deserializer<'de>,
 {
     // IndexMap preserves the order from the config file, which is why it's used instead of HashMap.
-    let remap = IndexMap::<KeyPress, Actions>::deserialize(deserializer)?;
+    let remap = IndexMap::<KeyPress, VectorOrSingleOrNull<KeymapAction>>::deserialize(deserializer)?;
     Ok(remap
         .into_iter()
         .map(|(key_press, actions)| (key_press, actions.into_vec()))

--- a/src/config/keymap_action.rs
+++ b/src/config/keymap_action.rs
@@ -168,30 +168,10 @@ fn deserialize_action_without_args<'de, D: Deserializer<'de>>(deserializer: D) -
     deserialize_single_field(deserializer, "action")
 }
 
-// Used only for deserializing Vec<Action>
-#[derive(Clone, Debug, Deserialize)]
-#[serde(untagged)]
-pub enum Actions {
-    // Allows keychords to map to null, which means no actions.
-    NoAction,
-    Action(KeymapAction),
-    Actions(Vec<KeymapAction>),
-}
-
-impl Actions {
-    pub fn into_vec(self) -> Vec<KeymapAction> {
-        match self {
-            Actions::NoAction => vec![],
-            Actions::Action(action) => vec![action],
-            Actions::Actions(actions) => actions,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::config::key_press::{KeyPress, Modifier};
-    use crate::config::keymap_action::{Actions, KeymapAction};
+    use crate::config::keymap_action::KeymapAction;
     use evdev::KeyCode as Key;
 
     #[test]
@@ -209,14 +189,6 @@ mod tests {
     fn test_launch_action() {
         test_yaml_parsing_key_launch("{launch: []}", vec![]);
         test_yaml_parsing_key_launch("{launch: [\"bla\"]}", vec!["bla".into()]);
-    }
-
-    #[test]
-    fn test_null_action() {
-        if let Actions::NoAction = serde_yaml::from_str("null").unwrap() {
-            return;
-        }
-        panic!("unexpected type");
     }
 
     //

--- a/src/config/modmap_operator.rs
+++ b/src/config/modmap_operator.rs
@@ -1,6 +1,6 @@
 use super::deserialize_keys;
-use super::keymap_action::{Actions, KeymapAction};
-use crate::config::deserializers::deserialize_duration;
+use super::keymap_action::KeymapAction;
+use crate::config::deserializers::{deserialize_duration, VectorOrSingleOrNull};
 use crate::config::key::{deserialize_key, parse_key};
 use evdev::KeyCode as Key;
 use serde::{Deserialize, Deserializer};
@@ -109,7 +109,7 @@ pub fn deserialize_actions<'de, D>(deserializer: D) -> Result<Vec<KeymapAction>,
 where
     D: Deserializer<'de>,
 {
-    let actions = Actions::deserialize(deserializer)?;
+    let actions = VectorOrSingleOrNull::<KeymapAction>::deserialize(deserializer)?;
     Ok(actions.into_vec())
 }
 

--- a/src/config/nested_remap.rs
+++ b/src/config/nested_remap.rs
@@ -1,7 +1,8 @@
 use crate::config::application::deserialize_string_or_vec;
+use crate::config::deserializers::VectorOrSingleOrNull;
 use crate::config::key::parse_key;
 use crate::config::key_press::KeyPress;
-use crate::config::keymap_action::{Actions, KeymapAction};
+use crate::config::keymap_action::KeymapAction;
 use evdev::KeyCode as Key;
 use indexmap::IndexMap;
 use serde::{de, Deserialize, Deserializer};
@@ -17,7 +18,7 @@ pub struct Remap {
 // Used only for deserialization
 #[derive(Debug, Deserialize)]
 pub struct RemapActions {
-    pub remap: IndexMap<KeyPress, Actions>,
+    pub remap: IndexMap<KeyPress, VectorOrSingleOrNull<KeymapAction>>,
     pub timeout_millis: Option<u64>,
     #[serde(default, deserialize_with = "deserialize_string_or_vec")]
     pub timeout_key: Option<Vec<String>>,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -225,7 +225,7 @@ fn test_yaml_press_release_key_wrongly_used_in_keymap() {
 
     assert_eq!(
         &errmsg,
-        "keymap[0].remap: data did not match any variant of untagged enum Actions at line 3 column 7"
+        "keymap[0].remap: data did not match any variant of untagged enum VectorOrSingleOrNull at line 3 column 7"
     );
 }
 
@@ -242,7 +242,7 @@ fn test_yaml_modifier_is_missing_sidedness() {
 
     assert_eq!(
         &errmsg,
-        "keymap[0].remap: data did not match any variant of untagged enum Actions at line 3 column 7"
+        "keymap[0].remap: data did not match any variant of untagged enum VectorOrSingleOrNull at line 3 column 7"
     );
 }
 
@@ -259,7 +259,7 @@ fn test_yaml_key_is_unknown() {
 
     assert_eq!(
         &errmsg,
-        "keymap[0].remap: data did not match any variant of untagged enum Actions at line 3 column 7"
+        "keymap[0].remap: data did not match any variant of untagged enum VectorOrSingleOrNull at line 3 column 7"
     );
 }
 
@@ -305,7 +305,7 @@ fn test_yaml_keymap_remap_timeout_key_invalid() {
 
     assert_eq!(
         &errmsg,
-        "keymap[0].remap: data did not match any variant of untagged enum Actions at line 3 column 7"
+        "keymap[0].remap: data did not match any variant of untagged enum VectorOrSingleOrNull at line 3 column 7"
     );
 }
 
@@ -324,7 +324,7 @@ fn test_yaml_keymap_remap_timeout_invalid() {
 
     assert_eq!(
         &errmsg,
-        "keymap[0].remap: data did not match any variant of untagged enum Actions at line 3 column 7"
+        "keymap[0].remap: data did not match any variant of untagged enum VectorOrSingleOrNull at line 3 column 7"
     );
 }
 

--- a/src/operator_handler.rs
+++ b/src/operator_handler.rs
@@ -54,13 +54,7 @@ impl OperatorHandler {
             }
 
             for (key, op) in &expmap.remap {
-                let operators = match op {
-                    ExpmapOperator::DoubleTap(dbltap) => {
-                        DoubleTapOperator::get_ops(*key, dbltap, timeout_manager.clone())
-                    }
-                    ExpmapOperator::Throttle(timeout) => ThrottleOperator::get_ops(*key, *timeout),
-                    ExpmapOperator::OneShot(action) => OneshotOperator::get_ops(*key, *action),
-                };
+                let operators = get_static_operators(*key, op, &timeout_manager);
                 append(operators, &mut lookup_map, expmap);
             }
         }
@@ -97,6 +91,23 @@ impl OperatorHandler {
                 self.emit_handler.map_output(events)
             })
             .collect()
+    }
+}
+
+/// Makes the static operators, that is needed for the given configuration file definition.
+fn get_static_operators(
+    key: Key,
+    op: &ExpmapOperator,
+    timeout_manager: &Rc<TimeoutManager>,
+) -> Vec<(Key, Box<dyn StaticOperator>)> {
+    match op {
+        ExpmapOperator::DoubleTap(dbltap) => DoubleTapOperator::get_ops(key, dbltap, timeout_manager.clone()),
+        ExpmapOperator::Throttle(timeout) => ThrottleOperator::get_ops(key, *timeout),
+        ExpmapOperator::OneShot(action) => OneshotOperator::get_ops(key, *action),
+        ExpmapOperator::Select(operators) => operators
+            .iter()
+            .flat_map(|operator| get_static_operators(key, operator, &timeout_manager))
+            .collect(),
     }
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod tests_nested_remap;
 mod tests_operator_double_tap;
 mod tests_operator_handler;
 mod tests_operator_oneshot;
+mod tests_operator_select;
 mod tests_operator_sim;
 mod tests_operator_throttle;
 mod tests_throttle_emit;

--- a/src/tests/tests.rs
+++ b/src/tests/tests.rs
@@ -539,7 +539,7 @@ fn test_keymap_action_error() {
 
     assert_eq!(
         &errmsg,
-        "keymap[0].remap: data did not match any variant of untagged enum Actions at line 3 column 9"
+        "keymap[0].remap: data did not match any variant of untagged enum VectorOrSingleOrNull at line 3 column 9"
     );
 }
 

--- a/src/tests/tests_operator_select.rs
+++ b/src/tests/tests_operator_select.rs
@@ -1,0 +1,141 @@
+use crate::event::Event;
+use crate::operator_handler::OperatorHandler;
+use crate::tests::{assert_events, get_handler_from_config};
+use evdev::KeyCode as Key;
+use indoc::indoc;
+use std::time::Duration;
+
+static TIMEOUT: Duration = Duration::from_millis(10);
+
+fn get_dbltap_handler() -> OperatorHandler {
+    get_handler_from_config(indoc! {"
+        experimental_map:
+          - remap:
+              A:
+                select:
+                  - double: B
+                    timeout: 5
+                  - double: C
+        "})
+    .unwrap()
+}
+
+#[test]
+fn test_expmap_two_double_taps_on_same_key_first_match() {
+    let mut handler = get_dbltap_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_B)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_B)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_expmap_two_double_taps_on_same_key_last_match() {
+    let mut handler = get_dbltap_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+
+    std::thread::sleep(TIMEOUT); // Enough timeout, so first doesn't match.
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![]);
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_C)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_C)]);
+
+    handler.assert_base_state();
+}
+
+fn get_throttle_handler() -> OperatorHandler {
+    get_handler_from_config(indoc! {"
+        experimental_map:
+          - remap:
+              A:
+                select:
+                  - throttle_ms: 5
+                  - double: B
+        "})
+    .unwrap()
+}
+
+#[test]
+fn test_expmap_throttle_output_is_not_used_by_lower_priority_operator() {
+    let mut handler = get_throttle_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+
+    std::thread::sleep(TIMEOUT); // So it goes into done state
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_expmap_throttle_output_is_not_used_by_lower_priority_operator_double_press() {
+    let mut handler = get_throttle_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+    std::thread::sleep(TIMEOUT); // So it goes into done state
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_A)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_A)]);
+    std::thread::sleep(TIMEOUT); // So it goes into done state
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_K)]), vec![Event::key_press(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}
+
+fn get_oneshot_handler() -> OperatorHandler {
+    get_handler_from_config(indoc! {"
+        experimental_map:
+          - remap:
+              A:
+                select:
+                  - double: B
+                    timeout: 5
+                  - oneshot: S_L
+        "})
+    .unwrap()
+}
+
+#[test]
+fn test_expmap_oneshot_after_fast_double_tap() {
+    let mut handler = get_oneshot_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![Event::key_press(Key::KEY_B)]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![Event::key_release(Key::KEY_B)]);
+
+    handler.assert_base_state();
+}
+
+#[test]
+fn test_expmap_oneshot_after_slow_double_tap() {
+    let mut handler = get_oneshot_handler();
+
+    assert_events(handler.map_evs(vec![Event::key_press(Key::KEY_A)]), vec![]);
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_A)]), vec![]);
+
+    std::thread::sleep(TIMEOUT);
+    // dbltap cancels, and oneshot is emitted.
+    assert_events(handler.map_evs(vec![Event::Tick]), vec![Event::key_press(Key::KEY_LEFTSHIFT)]);
+
+    assert_events(
+        handler.map_evs(vec![Event::key_press(Key::KEY_K)]),
+        vec![Event::key_press(Key::KEY_K), Event::key_release(Key::KEY_LEFTSHIFT)],
+    );
+    assert_events(handler.map_evs(vec![Event::key_release(Key::KEY_K)]), vec![Event::key_release(Key::KEY_K)]);
+
+    handler.assert_base_state();
+}


### PR DESCRIPTION
`select` chooses exactly one of several operators, that take a small `timeout` to decide if they match.

Implementation wise is `select` trivial, it only flattens its arguments, because `OperatorHandler` already functions this exact way.

Example:
```yml
experimental_map:
  - remap:
      s_l:
        select:
          - { double: B }
          - { oneshot: s_l }
```

### Description

`select` takes a list of operators and chooses the first in order, that matches. That operator
will get all the events, and the other operators will get no events and have no visible effect.

Operators have the ability to defer decision of whether they match events, the events are buffered
until a decision is made. This makes it possible for fx `double` tap to completely squash the
key that triggered it.

Documentation: https://github.com/xremap/xremap/blob/master/doc/reference_select.md